### PR TITLE
feature: Specify mime precedence using ":display" in org source blocks

### DIFF
--- a/README.org
+++ b/README.org
@@ -352,6 +352,21 @@ Since it is possible to determine how a result should be represented in
 Currently this is only the =:file= argument for image results and =:results
 raw= for inserting raw latex fragments sent by the kernel.
 
+*** Changing the mime-type priority with :display
+
+The priority of mimetypes used to display results can be overwritten using the
+=:display= option. If instead of displaying HTML results we'd wish to display
+plain text, the argument =:display text/plain text/html= would prioritize plain
+text results over html ones. The following example displays plain text instead
+of HTML:
+#+BEGIN_SRC org
+,#+BEGIN_SRC jupyter-python :session py :display plain
+import pandas as pd
+data = [[1, 2], [3, 4]]
+pd.DataFrame(data, columns=["Foo", "Bar"])
+,#+END_SRC
+#+END_SRC
+
 *** Image output without the =:file= header argument
 
 For images sent by the kernel, if no =:file= parameter is provided to the code

--- a/README.org
+++ b/README.org
@@ -352,7 +352,7 @@ Since it is possible to determine how a result should be represented in
 Currently this is only the =:file= argument for image results and =:results
 raw= for inserting raw latex fragments sent by the kernel.
 
-*** Changing the mime-type priority with :display
+*** Changing the mime-type priority with the =:display= argument
 
 The priority of mimetypes used to display results can be overwritten using the
 =:display= option. If instead of displaying HTML results we'd wish to display

--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -782,13 +782,16 @@ which the above call returns a non-nil value. PARAMS is the REQ's
 `jupyter-org-request-block-params', DATA and METADATA are the
 data and metadata of the current MIME type."
   (cl-assert plist json-plist)
-  (let ((params (jupyter-org-request-block-params req)))
+  (let* ((params (jupyter-org-request-block-params req))
+         (display-mime-types (jupyter-org--find-mime-types
+                              (alist-get :display params nil))))
     (when (jupyter-org-request-file req)
       (push (cons :file (jupyter-org-request-file req)) params))
     (cl-destructuring-bind (data metadata)
         (jupyter-normalize-data plist metadata)
       (or (jupyter-loop-over-mime
-              jupyter-org-mime-types mime data metadata
+              (or display-mime-types jupyter-org-mime-types)
+              mime data metadata
             (jupyter-org-result mime params data metadata))
           (prog1 nil
             (warn "No valid mimetype found %s"
@@ -1008,6 +1011,30 @@ is a stream result. Otherwise return nil."
        0))
     (when (looking-at-p "\\(?::[\t ]\\|#\\+END_EXAMPLE\\)")
       (line-end-position (unless (eq (char-after) ?:) 0)))))
+
+(defun jupyter-org--find-mime-types (req-types)
+  "Return the keywords in `jupyter-org-mime-types' that match REQ-TYPES.
+
+If a match is not found, return nil. Try to be intelligent and
+return what the user might intend to use.
+
+REQ-TYPES can be a strings such as `plain', `plain html' or
+`text/plain'. The string `text' is translated to `:text/plain'
+and `image' to `:image/png'."
+  (and req-types ;; proceed only if REQ-TYPES is not nil
+       ;; iterate every specified REQ-TYPE looking for matches in MIME-TYPES
+       (mapcar (lambda (req-type)
+                 (cond
+                  ((not req-type) nil)
+                  ((string= req-type "text") :text/plain)
+                  ((string= req-type "image") :image/png)
+                  (t (let ((regexp (if (string-match "/" req-type)
+                                       req-type
+                                     (concat "/" req-type "$"))))
+                       (cl-loop for ii in jupyter-org-mime-types
+                                if (string-match regexp (symbol-name ii))
+                                return ii)))))
+               (split-string req-types))))
 
 ;;;;; Fixed width -> example block promotion
 

--- a/test/jupyter-test.el
+++ b/test/jupyter-test.el
@@ -1560,6 +1560,16 @@ os.path.abspath(os.getcwd())"
                      ;; `default-directory'
                      (substring default-directory nil -1)))))))
 
+(ert-deftest jupyter-org--find-mime-types ()
+  :tags '(org mime)
+  (ert-info ("Mimetype priority overwrite")
+    (should (equal (jupyter-org--find-mime-types "text") '(:text/plain)))
+    (should (equal (jupyter-org--find-mime-types "image") '(:image/png)))
+    (should (equal (jupyter-org--find-mime-types "plain html") '(:text/plain :text/html)))
+    (should (equal (jupyter-org--find-mime-types "org jpeg") '(:text/org :image/jpeg)))
+    (should (equal (jupyter-org--find-mime-types "plain foo html bar") '(:text/plain :text/html)))
+    (should (equal (jupyter-org--find-mime-types "foo bar") '()))))
+
 ;; Local Variables:
 ;; byte-compile-warnings: (not free-vars)
 ;; End:


### PR DESCRIPTION
A BEGIN_SRC block can specify which mime type to display by enabling the
user to manually set the priority order of mime types.

e.g.:
In the following, :text/plain will be used before considering :text/html
\#BEGIN_SRC jupy-python :display plain html