### PR TITLE
Add variable to change output to tooltip instead of message

### DIFF
--- a/jupyter-client.el
+++ b/jupyter-client.el
@@ -38,15 +38,23 @@
 (require 'jupyter-messages)
 
 (defcustom jupyter-display-short-eval-result-function #'message
-  "Function used for displaying the result of evaluation which is
-less than 10 lines long. The variable defaults to `message' which
-outputs to the minibuffer.
+  "Function for displaying short evaluation results.
+Evaluation results are cosidered short in case they are less than
+`jupyter-display-short-eval-result-max-lines' lines long.
+The variable defaults to `message' which outputs to the minibuffer.
 
 Any function can be used which takes a string as first argument.
 For example to display the result in a tooltip the variable can
 be set to `popup-tip' from `popup'"
   :group 'jupyter-client
   :type 'function)
+
+(defcustom jupyter-display-short-eval-result-max-lines 10
+  "Maximum number of lines for evaluation results to still be considered short.
+Short evaluation results are displayed using `jupyter-display-short-eval-result-function'.
+Longer results are forwarded to a separate buffer."
+  :group 'jupyter-client
+  :type 'integer)
 
 (declare-function company-begin-backend "ext:company" (backend &optional callback))
 (declare-function company-doc-buffer "ext:company" (&optional string))
@@ -965,7 +973,7 @@ Methods that extend this generic function should
       (if (cl-loop
            with nlines = 0
            for c across res when (eq c ?\n) do (cl-incf nlines)
-           thereis (> nlines 10))
+           thereis (> nlines jupyter-display-short-eval-result-max-lines))
           (jupyter-with-display-buffer "result" 'reset
             (insert res)
             (goto-char (point-min))
@@ -1000,10 +1008,10 @@ text/plain representation."
 Replaces the contents of the last cell in the REPL buffer with
 STR before evaluating.
 
-If the result of evaluation is more than 10 lines long, a buffer
-displaying the results is shown. For results less than 10 lines
-long, the result is displayed with
-`jupyter-display-short-eval-result-function'.
+If the result of evaluation is more than
+`jupyter-display-short-eval-result-max-lines' lines long, a buffer
+displaying the results is shown. For less lines, the result is
+displayed with `jupyter-display-short-eval-result-function'.
 
 CB is a function to call with the `:execute-result' message when
 the evalution is successful. When CB is nil, its behavior defaults

--- a/jupyter-client.el
+++ b/jupyter-client.el
@@ -37,6 +37,17 @@
 (require 'jupyter-mime)
 (require 'jupyter-messages)
 
+(defcustom jupyter-display-short-eval-result-function #'message
+  "Function used for displaying the result of evaluation which is
+less than 10 lines long. The variable defaults to `message' which
+outputs to the minibuffer.
+
+Any function can be used which takes a string as first argument.
+For example to display the result in a tooltip the variable can
+be set to `popup-tip' from `popup'"
+  :group 'jupyter-client
+  :type 'function)
+
 (declare-function company-begin-backend "ext:company" (backend &optional callback))
 (declare-function company-doc-buffer "ext:company" (&optional string))
 (declare-function company-idle-begin "ext:company")
@@ -959,7 +970,7 @@ Methods that extend this generic function should
             (insert res)
             (goto-char (point-min))
             (display-buffer (current-buffer)))
-        (message "%s" res)))))
+        (funcall jupyter-display-short-eval-result-function (format "%s" res))))))
 
 (defun jupyter-eval (code &optional mime)
   "Send an execute request for CODE, wait for the execute result.
@@ -991,7 +1002,8 @@ STR before evaluating.
 
 If the result of evaluation is more than 10 lines long, a buffer
 displaying the results is shown. For results less than 10 lines
-long, the result is displayed in the minibuffer.
+long, the result is displayed with
+`jupyter-display-short-eval-result-function'.
 
 CB is a function to call with the `:execute-result' message when
 the evalution is successful. When CB is nil, its behavior defaults

--- a/jupyter-client.el
+++ b/jupyter-client.el
@@ -37,22 +37,23 @@
 (require 'jupyter-mime)
 (require 'jupyter-messages)
 
-(defcustom jupyter-display-short-eval-result-function #'message
+(defcustom jupyter-eval-short-result-display-function #'message
   "Function for displaying short evaluation results.
-Evaluation results are cosidered short in case they are less than
-`jupyter-display-short-eval-result-max-lines' lines long.
-The variable defaults to `message' which outputs to the minibuffer.
+Evaluation results are considered short when they are less than
+`jupyter-eval-short-result-max-lines' long. The variable
+defaults to `message' which outputs to the minibuffer.
 
-Any function can be used which takes a string as first argument.
-For example to display the result in a tooltip the variable can
-be set to `popup-tip' from `popup'"
+Any function can be used which takes a string as first argument. For
+example to display the result in a tooltip the variable can be set to
+`popup-tip' from the `popup' package."
   :group 'jupyter-client
   :type 'function)
 
-(defcustom jupyter-display-short-eval-result-max-lines 10
-  "Maximum number of lines for evaluation results to still be considered short.
-Short evaluation results are displayed using `jupyter-display-short-eval-result-function'.
-Longer results are forwarded to a separate buffer."
+(defcustom jupyter-eval-short-result-max-lines 10
+  "Maximum number of lines for evaluation results to still be
+considered short. Short evaluation results are displayed using
+`jupyter-eval-short-result-display-function'. Longer results are
+forwarded to a separate buffer."
   :group 'jupyter-client
   :type 'integer)
 
@@ -973,12 +974,12 @@ Methods that extend this generic function should
       (if (cl-loop
            with nlines = 0
            for c across res when (eq c ?\n) do (cl-incf nlines)
-           thereis (> nlines jupyter-display-short-eval-result-max-lines))
+           thereis (> nlines jupyter-eval-short-result-max-lines))
           (jupyter-with-display-buffer "result" 'reset
             (insert res)
             (goto-char (point-min))
             (display-buffer (current-buffer)))
-        (funcall jupyter-display-short-eval-result-function (format "%s" res))))))
+        (funcall jupyter-eval-short-result-display-function (format "%s" res))))))
 
 (defun jupyter-eval (code &optional mime)
   "Send an execute request for CODE, wait for the execute result.
@@ -1009,9 +1010,9 @@ Replaces the contents of the last cell in the REPL buffer with
 STR before evaluating.
 
 If the result of evaluation is more than
-`jupyter-display-short-eval-result-max-lines' lines long, a buffer
+`jupyter-eval-short-result-max-lines' long, a buffer
 displaying the results is shown. For less lines, the result is
-displayed with `jupyter-display-short-eval-result-function'.
+displayed with `jupyter-eval-short-result-display-function'.
 
 CB is a function to call with the `:execute-result' message when
 the evalution is successful. When CB is nil, its behavior defaults


### PR DESCRIPTION
I added a custom variable to allow usage of tooltips instead of `message` for short messages.
![image](https://user-images.githubusercontent.com/13043943/52429070-a7b40580-2b03-11e9-8735-12bec332661a.png)
For longer return values the output is still forwarded to a buffer.
I implemented it with a customizable variable `jupyter-display-output-function` that is a symbol (either `'message` or `'tooltip`) which is then checked in a `cond` to ensure that only those two cases are used and no arbitrary function can be added.

I hope my code somewhat matches the style of this package