### PR TITLE
Handle ANSI escape sequences in `org-mode` src-block results

### DIFF
--- a/jupyter-mime.el
+++ b/jupyter-mime.el
@@ -184,6 +184,69 @@ function."
         (kill-buffer)))
     (funcall restore-mode)))
 
+;;; Special handling of ANSI sequences
+
+(defun jupyter-ansi-color-apply-on-region (begin end)
+  "`ansi-color-apply-on-region' with Jupyter specific modifications.
+In particular, does not delete escape sequences between BEGIN and
+END from the buffer. Instead, an invisible text property with a
+value of t is added to render the escape sequences invisible.
+Also, the `ansi-color-apply-face-function' is hard-coded to a
+custom function that prepends to the face property of the text
+and also sets the font-lock-face to the prepended face.
+
+For convenience, a jupyter-invisible property is also added with
+a value of t. This is mainly for modes like `org-mode' which
+strip invisible properties during fontification. In such cases,
+the jupyter-invisible property can act as an alias to the
+invisible property by adding it to `char-property-alias-alist'."
+  (let ((codes (car ansi-color-context-region))
+        (start-marker (or (cadr ansi-color-context-region)
+                          (copy-marker begin)))
+        (end-marker (copy-marker end))
+        (ansi-color-apply-face-function
+         (lambda (beg end face)
+           (when face
+             (setq face (list face))
+             (font-lock-prepend-text-property beg end 'face face)
+             (put-text-property beg end 'font-lock-face face)))))
+    (save-excursion
+      (goto-char start-marker)
+      ;; Find the next escape sequence.
+      (while (re-search-forward ansi-color-control-seq-regexp end-marker t)
+        ;; Remove escape sequence.
+        (let ((esc-seq (prog1 (buffer-substring-no-properties
+                               (match-beginning 0) (point))
+                         ;; FIXME: Not removing escape sequences adds in a lot
+                         ;; of invisible characters that slows down Emacs on
+                         ;; large ANSI coded regions and seems mostly related
+                         ;; to redisplay since hiding the region behind an
+                         ;; invisible overlay removes the slowdown.
+                         (add-text-properties
+                          (match-beginning 0) (point)
+                          '(invisible t jupyter-invisible t)))))
+          ;; Colorize the old block from start to end using old face.
+          (funcall ansi-color-apply-face-function
+                   (prog1 (marker-position start-marker)
+                     ;; Store new start position.
+                     (set-marker start-marker (point)))
+                   (match-beginning 0) (ansi-color--find-face codes))
+          ;; If this is a color sequence,
+          (when (eq (aref esc-seq (1- (length esc-seq))) ?m)
+            ;; update the list of ansi codes.
+            (setq codes (ansi-color-apply-sequence esc-seq codes)))))
+      ;; search for the possible start of a new escape sequence
+      (if (re-search-forward "\033" end-marker t)
+          (progn
+            ;; if the rest of the region should have a face, put it there
+            (funcall ansi-color-apply-face-function
+                     start-marker end-marker (ansi-color--find-face codes))
+            (setq ansi-color-context-region (if codes (list codes))))
+        ;; if the rest of the region should have a face, put it there
+        (funcall ansi-color-apply-face-function
+                 start-marker end-marker (ansi-color--find-face codes))
+        (setq ansi-color-context-region (if codes (list codes)))))))
+
 ;;; `jupyter-insert' method
 
 (cl-defgeneric jupyter-insert (_mime _data &optional _metadata)

--- a/ob-jupyter.el
+++ b/ob-jupyter.el
@@ -431,10 +431,24 @@ mapped to their appropriate minted language in
      do (cl-pushnew (list (intern (concat "jupyter-" lang)) lang)
                     org-latex-minted-langs :test #'equal)))))
 
+(defun org-babel-jupyter-strip-ansi-escapes (_backend)
+  "Remove ANSI escapes from Jupyter src-block results in the current buffer."
+  (org-babel-map-src-blocks nil
+    (when-let* ((jupyter-p (org-babel-jupyter-language-p lang))
+                (pos (org-babel-where-is-src-block-result))
+                (ansi-color-apply-face-function
+                 (lambda (beg end face)
+                   ;; Could be useful for export backends
+                   (when face
+                     (put-text-property beg end 'face face)))))
+      (goto-char pos)
+      (ansi-color-apply-on-region (point) (org-babel-result-end)))))
+
 ;;; Hook into `org'
 
 (org-babel-jupyter-aliases-from-kernelspecs)
 (add-hook 'org-export-before-processing-hook #'org-babel-jupyter-setup-export)
+(add-hook 'org-export-before-parsing-hook #'org-babel-jupyter-strip-ansi-escapes)
 
 (provide 'ob-jupyter)
 


### PR DESCRIPTION
This pull request causes ANSI escape sequences in `org-mode` example blocks or fixed-width (lines that start with `: `) elements to be colored and the actual escape sequences are rendered invisible.

There are issues with this though, since now the escape sequences exist in the buffer instead of being removed before insertion. This means that when exporting to other formats those escape sequences will still be in the exported output.

One way to address this is to hook into `org-mode`'s export functionality and remove the escape sequences in the `example-block` and `fixed-width` elements that `org-mode` processes during export. This should only be done for `example-block` and `fixed-width` elements that are part of the results of Jupyter source blocks since there may be situations where exporting elements with ANSI escape sequences is wanted.

In fact, the features of this pull request should probably only be applied to Jupyter source block results. The current implementation applies to all ``example-block`` or ``fixed-width`` elements in the buffer whenever `jupyter-org-interaction-mode` is enabled.

Closes #55.
