### PR TITLE
Session awareness in `jupyter-org-execute-to-point`

### DIFF
--- a/jupyter-org-extensions.el
+++ b/jupyter-org-extensions.el
@@ -33,6 +33,7 @@
 (declare-function org-babel-jupyter-initiate-session "ob-jupyter" (&optional session params))
 (declare-function org-babel-jupyter-src-block-session "ob-jupyter" ())
 (declare-function org-in-src-block-p "org" (&optional inside))
+(declare-function org-narrow-to-subtree "org" ())
 (declare-function org-element-context "org-element" (&optional element))
 (declare-function org-element-property "org-element" (property element))
 (declare-function org-element-interpret-data "org-element" (data))
@@ -202,6 +203,17 @@ Jupyter source blocks."
           (org-babel-execute-src-block))))
     (goto-char p)
     (set-marker p nil)))
+
+;;;###autoload
+(defun jupyter-org-execute-subtree (any)
+  "Execute Jupyter source blocks that start before point in the current subtree.
+This function narrows the buffer to the current subtree and calls
+`jupyter-org-execute-to-point'. See that function for the meaning
+of the ANY argument."
+  (interactive "P")
+  (save-restriction
+    (org-narrow-to-subtree)
+    (jupyter-org-execute-to-point any)))
 
 ;;;###autoload
 (defun jupyter-org-inspect-src-block ()
@@ -461,16 +473,17 @@ If BELOW is non-nil, move the block down, otherwise move it up."
     _<return>_: current           _p_: previous  _C-p_: move up     _/_: inspect
   _C-<return>_: current to next   _n_: next      _C-n_: move down   _l_: clear result
   _M-<return>_: to point          _g_: visible     _x_: kill        _L_: clear all
-  _S-<return>_: Restart/block     _G_: any         _c_: copy
-_S-C-<return>_: Restart/to point  ^ ^              _o_: clone
-_S-M-<return>_: Restart/buffer    ^ ^              _m_: merge
-           _r_: Goto repl         ^ ^              _s_: split
-           ^ ^                    ^ ^              _+_: insert above
+_C-M-<return>_: subtree to point  _G_: any         _c_: copy
+  _S-<return>_: Restart/block     ^ ^              _o_: clone
+_S-C-<return>_: Restart/to point  ^ ^              _m_: merge
+_S-M-<return>_: Restart/buffer    ^ ^              _s_: split
+           _r_: Goto repl         ^ ^              _+_: insert above
            ^ ^                    ^ ^              _=_: insert below
            ^ ^                    ^ ^              _h_: header"
            ("<return>" org-ctrl-c-ctrl-c :color red)
            ("C-<return>" jupyter-org-execute-and-next-block :color red)
            ("M-<return>" jupyter-org-execute-to-point)
+           ("C-M-<return>" jupyter-org-execute-subtree)
            ("S-<return>" jupyter-org-restart-kernel-execute-block)
            ("S-C-<return>" jupyter-org-restart-and-execute-to-point)
            ("S-M-<return>" jupyter-org-restart-kernel-execute-buffer)

--- a/test/jupyter-test.el
+++ b/test/jupyter-test.el
@@ -1712,6 +1712,30 @@ AB[43mCD[0mEF
       (remove-text-properties (point-min) (point-max) '(face))
       (funcall test-fun 24 '(19 20 21 22 23 26 27 28 29)))))
 
+(ert-deftest org-babel-jupyter-src-block-session ()
+  :tags '(org)
+  (jupyter-org-test
+   (insert "\
+#+BEGIN_SRC jupyter-foo :session bar
+#+END_SRC")
+   (goto-char (point-min))
+   (should-error (org-babel-jupyter-src-block-session))
+   (erase-buffer)
+   (insert "\
+#+BEGIN_SRC jupyter-foo :kernel bar
+#+END_SRC")
+   (goto-char (point-min))
+   (should-error (org-babel-jupyter-src-block-session))
+   (erase-buffer)
+   (insert "\
+#+BEGIN_SRC jupyter-foo :session bar :kernel bar
+#+END_SRC")
+   (goto-char (point-min))
+   (should (equal (org-babel-jupyter-src-block-session)
+                  (org-babel-jupyter-session-key
+                   (nth 2 (org-babel-get-src-block-info 'light)))))
+   (erase-buffer)))
+
 (ert-deftest org-babel-jupyter-:results-header-arg ()
   :tags '(org)
   (ert-info ("scalar suppresses table output")


### PR DESCRIPTION
In the current version of `jupyter-org-execute-to-point`, all source blocks before point are executed indiscriminately of the `:session` header argument or whether the source block is a Jupyter source block. This is not much of an issue if one uses a single session per `org-mode` file, but becomes a problem when multiple sessions exist in various subtrees before point and when non-Jupyter source blocks are used in combination with Jupyter source blocks, e.g. when generating data files using `shell` source blocks which are subsequently processed by Jupyter source blocks.

This pull request extends `jupyter-org-execute-to-point` to consider the `:session` header argument by only evaluating Jupyter source blocks  that correspond to the same session as the source block at point or near point, see the documentation of `jupyter-org-execute-to-point` for the details on how a session is selected. Also, evaluation of non-Jupyter source blocks is controlled by providing a prefix argument.

The function `jupyter-org-execute-subtree` is added and uses `jupyter-org-execute-to-point` internally so that it is also aware of the Jupyter session. This function is added as the `C-M-<return>` binding in the hydra.

Closes #63.