### PR TITLE
Set show-trailing-whitespace to nil for jupyter buffers.

### DIFF
--- a/jupyter-base.el
+++ b/jupyter-base.el
@@ -296,6 +296,9 @@ See `jupyter-with-display-buffer'.")
     (unless buffer
       (setq buffer (get-buffer-create bname))
       (with-current-buffer buffer
+        ;; For buffers such as the jupyter REPL, showing trailing whitespaces
+        ;; may be a nuisance (as evidenced by the Python banner).
+        (setq-local show-trailing-whitespace nil)
         (unless (eq major-mode 'special-mode)
           (special-mode))))
     buffer))

--- a/jupyter-repl.el
+++ b/jupyter-repl.el
@@ -1551,6 +1551,8 @@ in the appropriate direction, to the saved element."
   "Jupyter-REPL"
   "A Jupyter REPL major mode."
   (cl-check-type jupyter-current-client jupyter-repl-client)
+  ;; This is a better setting for rendering language banners.
+  (setq-local show-trailing-whitespace nil)
   ;; This is a better setting when rendering HTML tables
   (setq-local truncate-lines t)
   (setq-local indent-line-function #'jupyter-repl-indent-line)


### PR DESCRIPTION
Closes  #79