### PR TITLE
Fix R parsing HTML table with spaces, using pandoc

### DIFF
--- a/jupyter-R.el
+++ b/jupyter-R.el
@@ -36,75 +36,28 @@
                                   &context (jupyter-lang R)
                                   &optional metadata)
   "Parse and convert DATA of type 'text/html' into a prettier form.
-If _METADATA has ':isolated' tag (e.g. DT::datatable()), save it to a file
-and open in a browser. Otherwise, if libxml is available and DATA
-is of type <table>, <ol>, <ul>, or <dl>, try to render it nicely."
-  (if (plist-get metadata :isolated)
-      ;; handle html with "isolated" property
+If METADATA has ':isolated' tag (e.g. DT::datatable()), save it to a file
+and open in a browser. Otherwise, try to use pandoc or libxml to convert
+DATA to a prettier form."
+  (cond
+   ((plist-get metadata :isolated)
       (let ((file (or (alist-get :file params)
                       (jupyter-org-image-file-name data ".html"))))
         (with-temp-file file
           (insert data))
         (browse-url-of-file file)
-        (jupyter-org-file-link file))
-    ;; handle html without "isolated" property
-    (if (functionp 'libxml-parse-html-region)
-        ;; parse with libxml
-        (with-temp-buffer
-          (insert data)
-          (let* ((parsed-html (libxml-parse-html-region
-                               (point-min) (point-max)))
-                 (inner-element
-                  (jupyter-org-result--R-html-inner-element parsed-html))
-                 (inner-element-type (car inner-element)))
-            (cl-case (car inner-element)
-              (table
-               (jupyter-org-result--R-html-table parsed-html))
-              ((ol dl ul)
-               (jupyter-org-result--R-html-list parsed-html))
-              (t (cl-call-next-method)))))
-      ;; libxml not available, call next method
-      (cl-call-next-method))))
-
-(defun jupyter-org-result--R-html-table (parsed-html)
-  "Convert PARSED-HTML into an org-element table."
-  (with-temp-buffer
-    (shr-insert-document parsed-html)
-    (org-table-convert-region (point-min) (point-max) nil)
-    (org-table-insert-hline)
-    (let* ((tbl (org-table-to-lisp))
-           (head (jupyter-org-result--R-html-table-fix-header (car tbl)))
-           (body (cdr tbl)))
-      (jupyter-org-scalar `(,head . ,body)))))
-
-(defun jupyter-org-result--R-html-table-fix-header (header)
-  "Shifts column names to the right if last element of HEADER is empty string.
-This fixes the header column alignment when the table has row names."
-  (if (equal "" (car (last header)))
-      `("" . ,(butlast header))
-    header))
-
-(defun jupyter-org-result--R-html-list (parsed-html)
-  "Renders list-like PARSED-HTML.
-Since these can have arbitrary nested structure, we don't try to parse it into
-an org-element; instead we just render the html.  Note this is still a bit
-uglier than ':display plain', which should be preferred for these outputs."
-  (with-temp-buffer
-    (shr-insert-document parsed-html)
-    (buffer-string)))
-
-(defun jupyter-org-result--R-html-inner-element (parsed-html)
-  "If PARSED-HTML consists of a body with 1 element, return that element.
-Otherwise, return nil."
-  (let ((html-subnodes (cdr (cdr parsed-html))))
-    ;; check there is 1 html-subnode and it is the body
-    (when (eq 1 (length html-subnodes))
-      (let ((body (car html-subnodes)))
-        (when (eq (car body) 'body)
-          ;; check the body has 1 subnode and return it
-          (let ((body-subnodes (cdr (cdr body))))
-            (when (eq 1 (length body-subnodes))
-              (car body-subnodes))))))))
+        (jupyter-org-file-link file)))
+   ((functionp 'pandoc-convert-stdio)
+    (jupyter-org-raw-string (pandoc-convert-stdio data "html" "org")))
+   ((functionp 'libxml-parse-html-region)
+    (with-temp-buffer
+      (insert data)
+      (let ((parsed-html (libxml-parse-html-region
+                          (point-min) (point-max))))
+        (erase-buffer)
+        (shr-insert-document parsed-html)
+        (buffer-string))))
+   (t (cl-call-next-method))))
 
 (provide 'jupyter-R)
 

--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -1028,6 +1028,7 @@ parsed, wrap DATA in a minipage environment and return it."
        (with-temp-buffer
          (insert (jupyter-pandoc-convert "html" "org" data))
          (goto-char (point-min))
+         (delete-trailing-whitespace)
          (if (and (org-at-table-p)
                   (eq (org-table-end) (point-max)))
              (org-table-to-lisp)


### PR DESCRIPTION
Sorry to be revisiting this so soon -- I found a bug already in `jupyter-R.el` :-/

If a table has spaces, it gets parsed incorrectly, like so:
```
#+begin_src jupyter-R :session R
  data.frame(x=c("a", "b c", "d"), y=1:3)
#+end_src

#+RESULTS:
|   | x | y |
|---+---+---|
| a | 1 |   |
| b | c | 2 |
| d | 3 |   |
```
The second entry of the "x" column should be "b c" but it gets split into an extra column, and the rest of the table is mangled as a consequence.

I decided to try an alternate approach. If `pandoc.el` is available, use it to convert HTML output to org-mode. Otherwise, if libxml is available, use shr to render it -- don't try to do any HTML parsing ourselves. This simplifies the code a bit, hopefully making it more maintainable.

Here's some examples. Table output when pandoc is available:
```
#+begin_src jupyter-R :session R
  data.frame(x=c("a", "b c", "d"), y=1:3)
#+end_src

#+RESULTS:
:RESULTS:
| x     | y   |
|-------+-----|
| a     | 1   |
| b c   | 2   |
| d     | 3   |
:END:
```
Libxml table output:
```
#+begin_src jupyter-R :session R
  data.frame(x=c("a", "b c", "d"), y=1:3)
#+end_src

#+RESULTS:
:   x  y    
:   a   1     
:   b c  2     
:   d   3     
```
Pandoc output of structured list:
```
#+begin_src jupyter-R :session R :display html
  foo = data.frame(a=letters[1:3], b=1:3)
  list(foo, 1:3, c=foo)
#+end_src

#+RESULTS:
:RESULTS:
- [[1]] :: | a   | b   |
  |-----+-----|
  | a   | 1   |
  | b   | 2   |
  | c   | 3   |

- [[2]] :: 

  1. 1
  2. 2
  3. 3

- $c :: | a   | b   |
  |-----+-----|
  | a   | 1   |
  | b   | 2   |
  | c   | 3   |
:END:
```
The nested list rendering is not perfect -- the inner table headers are shifted, and [[1]] and [[2]] get rendered as links. However it's still readable and not a huge deal IMO -- can always use `:display plain` for these sorts of edge cases.

An alternative which could be cool (if you're open to it) would be to support `pandoc.el` more generally, perhaps through a `:results pandoc` header property. Then we could remove the special handling of R html results. It might also be nice for pandas dataframes (https://github.com/dzop/emacs-jupyter/issues/88) -- that way people don't have to mess with their ipython startup files.