### PR TITLE
Add pandoc conversion of rich outputs

### DIFF
--- a/README.org
+++ b/README.org
@@ -490,6 +490,13 @@ generated image file names.
 Whenever you run a code block multiple times and replace its results, before
 the results are replaced, any generated files will be deleted to reduce the
 clutter in =org-babel-jupyter-resource-directory=.
+**** Convert rich kernel output with the =:pandoc= header argument
+
+By default html, markdown, and latex results are wrapped in a =BEGIN_EXPORT=
+block. If the header argument =:pandoc t= is set, they are instead
+converted to org-mode format with [[https://pandoc.org/][pandoc]]. You can control which outputs get
+converted with the custom variable =jupyter-org-pandoc-convertable=.
+
 *** Editing the contents of a code block
 
 When editing a Jupyter code block's contents, i.e. by pressing =C-c '= when at

--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -654,7 +654,7 @@ inserted without modification as the result of a code block."
   "Return a comment `org-element' with VALUE."
   (list 'comment (list :value value)))
 
-(defun jupyter-org-export-or-pandoc (type value params)
+(defun jupyter-org-export-block-or-pandoc (type value params)
   "Returns VALUE, either converted with pandoc or in an export block.
 If PARAMS has non-nil value for key ':pandoc' and TYPE is in
 `jupyter-org-pandoc-convertable', convert the result with pandoc.
@@ -973,7 +973,7 @@ passed to Jupyter org-mode source blocks."
 
 (cl-defmethod jupyter-org-result ((_mime (eql :text/markdown)) params data
                                   &optional _metadata)
-  (jupyter-org-export-or-pandoc "markdown" data params))
+  (jupyter-org-export-block-or-pandoc "markdown" data params))
 
 (defun jupyter-org--parse-latex-element (data)
   "Return a latex-fragment or latex-environment org-element obtained from DATA.
@@ -1005,11 +1005,11 @@ parsed, wrap DATA in a minipage environment and return it."
                                   &optional _metadata)
   (if (member "raw" (alist-get :result-params params))
       (jupyter-org--parse-latex-element data)
-    (jupyter-org-export-or-pandoc "latex" data params)))
+    (jupyter-org-export-block-or-pandoc "latex" data params)))
 
 (cl-defmethod jupyter-org-result ((_mime (eql :text/html)) params data
                                   &optional _metadata)
-  (jupyter-org-export-or-pandoc "html" data params))
+  (jupyter-org-export-block-or-pandoc "html" data params))
 
 ;; NOTE: The order of :around methods is that the more specialized wraps the
 ;; more general, this makes sense since it is how the primary methods work as


### PR DESCRIPTION
See also: https://github.com/dzop/emacs-jupyter/pull/91

As we discussed tables are currently output inside `:RESULTS:` drawers. I haven't implemented your suggestion to add an `org-table` text property, or the special parsing needed to determine when the property should be added. I've left that for a future issue/PR -- but let me know if you prefer I take care of it now, in which case I'll look into it.