### PR TITLE
Allow `:session` to be a remote file name for `org-mode` source blocks

### DIFF
--- a/CHANGELOG.org
+++ b/CHANGELOG.org
@@ -1,5 +1,11 @@
 * master
 
+- Allow =:session= to be a remote file name for =org-mode= source blocks. When
+  =:session= is a remote file name that doesn't end in =.json=, e.g.
+  =/ssh:ec2:jl=, a new kernel is started on the remote host using the
+  =jupyter kernel= command on that host. The local file name part serves to
+  distinguish different sessions on the remote host.
+
 - Add the new commands ~jupyter-repl-history-previous-matching~ and
   ~jupyter-repl-history-next-matching~, bound to ~C-c M-r~ and ~C-c M-s~ in the
   REPL.

--- a/README.org
+++ b/README.org
@@ -561,6 +561,13 @@ Host ec2
 #+END_SRC
 
 to your =~/.ssh/config= file.
+*** Starting a remote kernel
+
+If =:session= is a remote file name that doesn't end in =.json=, e.g.
+=/ssh:ec2:jl=, then a kernel on the remote host =/ssh:ec2:= is started using
+the =jupyter kernel= command on the host. The local part of the session name
+serves to distinguish different remote sessions on the same host.
+
 *** TODO Standard output, displayed data, and code block results
 
 One significant difference between Jupyter code blocks and regular =org-mode=


### PR DESCRIPTION
In this case a new kernel is started on the remote host and the remote kernel is used. So for a `:session` like `:session /ssh:ec2:foo`, a remote kernel is started on the host `ec2` and the name of the session on that host is `foo`.

~~The issue left to be solve is how to guarantee that the ports used on the remote host are actually available.~~ See https://github.com/dzop/emacs-jupyter/issues/72#issuecomment-485622333. One option is to have the ports be configurable per host as mentioned in https://github.com/dzop/emacs-jupyter/issues/72#issuecomment-486025535, perhaps by specifying a range of ports that can be used by `emacs-jupyter` on that host.

Closes #72.