### PR TITLE
Fix two org-src-lang-modes calc issues

### DIFF
--- a/ob-jupyter.el
+++ b/ob-jupyter.el
@@ -435,9 +435,9 @@ Optional argument REFRESH has the same meaning as in
                         (cdr (assoc lang org-babel-tangle-lang-exts)))))
    (add-to-list 'org-src-lang-modes
                 (cons (concat "jupyter-" lang)
-                      (intern (or (cdr (assoc lang org-src-lang-modes))
-                                  (replace-regexp-in-string
-                                   "[0-9]*" "" lang)))))))
+                      (or (cdr (assoc lang org-src-lang-modes))
+                          (downcase (replace-regexp-in-string
+                                     "[0-9]*" "" lang)))))))
 
 ;;; `ox' integration
 


### PR DESCRIPTION
For assoc lang org-src-lang-modes may return symbol sh, (inter 'sh) will
return an error.

For some languages like C++, the corresponding language mode shall be c++