### PR TITLE
Handle `isolated` metadata property for HTML results of the R kernel

### DIFF
--- a/jupyter-R.el
+++ b/jupyter-R.el
@@ -27,6 +27,7 @@
 
 (require 'jupyter-repl)
 (require 'jupyter-org-client)
+(require 'jupyter-mime)
 
 (defvar ess-font-lock-keywords)
 
@@ -47,6 +48,13 @@ Otherwise, parse it as normal."
           (insert data))
         (browse-url-of-file file)
         (jupyter-org-file-link file))
+    (cl-call-next-method)))
+
+(cl-defmethod jupyter-insert ((_mime (eql :text/html)) data
+                              &context (jupyter-lang R)
+                              &optional metadata)
+  (if (plist-get metadata :isolated)
+      (jupyter--insert-temp-file-browse-url data)
     (cl-call-next-method)))
 
 (provide 'jupyter-R)

--- a/jupyter-R.el
+++ b/jupyter-R.el
@@ -54,7 +54,7 @@ Otherwise, parse it as normal."
                               &context (jupyter-lang R)
                               &optional metadata)
   (if (plist-get metadata :isolated)
-      (jupyter--insert-temp-file-browse-url data)
+      (jupyter-browse-url-in-temp-file data)
     (cl-call-next-method)))
 
 (provide 'jupyter-R)

--- a/jupyter-client.el
+++ b/jupyter-client.el
@@ -977,9 +977,13 @@ to the above explanation."
         (setq had-result t)
         (jupyter-with-display-buffer "display" req
           (jupyter-insert data metadata)
-          (jupyter-display-current-buffer-reuse-window
-           :display-data nil (unless (jupyter-pop-up-frame-p :display-data)
-                               #'display-buffer-below-selected))))
+          (if (> (line-number-at-pos (point-max))
+                 jupyter-eval-short-result-max-lines)
+              (jupyter-display-current-buffer-reuse-window
+               :display-data nil (unless (jupyter-pop-up-frame-p :display-data)
+                                   #'display-buffer-below-selected))
+            (funcall jupyter-eval-short-result-display-function
+                     (buffer-string)))))
       :error
       (jupyter-message-lambda (traceback)
         ;; FIXME: Assumes the error in the

--- a/jupyter-client.el
+++ b/jupyter-client.el
@@ -977,9 +977,12 @@ to the above explanation."
         (setq had-result t)
         (jupyter-with-display-buffer "display" req
           (jupyter-insert data metadata)
-          (jupyter-display-current-buffer-reuse-window
-           :display-data nil (unless (jupyter-pop-up-frame-p :display-data)
-                               #'display-buffer-below-selected))))
+          ;; Don't pop-up the display when it's empty (e.g. jupyter-R
+          ;; will open some HTML results in an external browser)
+          (when (/= (point-min) (point-max))
+            (jupyter-display-current-buffer-reuse-window
+             :display-data nil (unless (jupyter-pop-up-frame-p :display-data)
+                                 #'display-buffer-below-selected)))))
       :error
       (jupyter-message-lambda (traceback)
         ;; FIXME: Assumes the error in the

--- a/jupyter-client.el
+++ b/jupyter-client.el
@@ -977,13 +977,9 @@ to the above explanation."
         (setq had-result t)
         (jupyter-with-display-buffer "display" req
           (jupyter-insert data metadata)
-          (if (> (line-number-at-pos (point-max))
-                 jupyter-eval-short-result-max-lines)
-              (jupyter-display-current-buffer-reuse-window
-               :display-data nil (unless (jupyter-pop-up-frame-p :display-data)
-                                   #'display-buffer-below-selected))
-            (funcall jupyter-eval-short-result-display-function
-                     (buffer-string)))))
+          (jupyter-display-current-buffer-reuse-window
+           :display-data nil (unless (jupyter-pop-up-frame-p :display-data)
+                               #'display-buffer-below-selected))))
       :error
       (jupyter-message-lambda (traceback)
         ;; FIXME: Assumes the error in the

--- a/jupyter-mime.el
+++ b/jupyter-mime.el
@@ -319,11 +319,10 @@ aligns on the current line."
     (browse-url-of-file file)
     ;; Give the external browser time to open the tmp file before deleting it
     ;; based on mm-display-external
-    (let ((file file))
-      (run-at-time
-       60.0 nil
-       (lambda ()
-         (ignore-errors (delete-file file)))))))
+    (run-at-time
+     60.0 nil
+     (lambda ()
+       (ignore-errors (delete-file file))))))
 
 (defun jupyter--delete-script-tags (beg end)
   (save-excursion

--- a/jupyter-mime.el
+++ b/jupyter-mime.el
@@ -313,6 +313,14 @@ aligns on the current line."
         (setf (image-property image :ascent) 50)
         (force-window-update)))))
 
+(defun jupyter-insert-html--maybe-browse-url (beg end)
+  (save-excursion
+    (save-restriction
+      (narrow-to-region beg end)
+      (goto-char beg)
+      (when (re-search-forward "<script[^>]*>" nil t)
+        (browse-url-of-buffer)))))
+
 (defun jupyter--delete-script-tags (beg end)
   (save-excursion
     (save-restriction
@@ -329,10 +337,9 @@ aligns on the current line."
   "Parse and insert the HTML string using `shr'."
   (jupyter-with-insertion-bounds
       beg end (insert html)
-    ;; TODO: We can't really do much about javascript so
-    ;; delete those regions instead of trying to parse
-    ;; them. Maybe just re-direct to a browser like with
-    ;; widgets?
+    ;; Maybe open the html in external browser (e.g. if it has javascript)
+    (jupyter-insert-html--maybe-browse-url beg end)
+    ;; Render non-javascript regions in the buffer
     ;; NOTE: Parsing takes a very long time when the text
     ;; is > ~500000 characters.
     (jupyter--delete-script-tags beg end)

--- a/jupyter-mime.el
+++ b/jupyter-mime.el
@@ -313,7 +313,8 @@ aligns on the current line."
         (setf (image-property image :ascent) 50)
         (force-window-update)))))
 
-(defun jupyter--insert-temp-file-browse-url (data)
+(defun jupyter-browse-url-in-temp-file (data)
+  "Insert DATA into a temp file and call `browse-url-of-file' on it."
   (let ((file (make-temp-file "emacs-jupyter" nil ".html")))
     (with-temp-file file (insert data))
     (browse-url-of-file file)

--- a/jupyter-mime.el
+++ b/jupyter-mime.el
@@ -313,14 +313,6 @@ aligns on the current line."
         (setf (image-property image :ascent) 50)
         (force-window-update)))))
 
-(defun jupyter-insert-html--maybe-browse-url (beg end)
-  (save-excursion
-    (save-restriction
-      (narrow-to-region beg end)
-      (goto-char beg)
-      (when (re-search-forward "<script[^>]*>" nil t)
-        (browse-url-of-buffer)))))
-
 (defun jupyter--delete-script-tags (beg end)
   (save-excursion
     (save-restriction
@@ -337,9 +329,10 @@ aligns on the current line."
   "Parse and insert the HTML string using `shr'."
   (jupyter-with-insertion-bounds
       beg end (insert html)
-    ;; Maybe open the html in external browser (e.g. if it has javascript)
-    (jupyter-insert-html--maybe-browse-url beg end)
-    ;; Render non-javascript regions in the buffer
+    ;; TODO: We can't really do much about javascript so
+    ;; delete those regions instead of trying to parse
+    ;; them. Maybe just re-direct to a browser like with
+    ;; widgets?
     ;; NOTE: Parsing takes a very long time when the text
     ;; is > ~500000 characters.
     (jupyter--delete-script-tags beg end)

--- a/jupyter-mime.el
+++ b/jupyter-mime.el
@@ -319,7 +319,7 @@ aligns on the current line."
     (browse-url-of-file file)
     ;; Give the external browser time to open the tmp file before deleting it
     ;; based on mm-display-external
-    (lexical-let ((file file))
+    (let ((file file))
       (run-at-time
        60.0 nil
        (lambda ()


### PR DESCRIPTION
I'd like to have the REPL handle html outputs with `<script>` tags. I've implemented this by using `browse-url-of-buffer` to open in an external browser when the `<script>` tag is detected.

My immediate motivation was to easily inspect R dataframes with the javascript DataTables library via  R's [DT](https://rstudio.github.io/DT/) package.
