### PR TITLE
Add support for the notebook server kernel and kernelspecs API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - sudo pip3 install --upgrade setuptools pip &> /dev/null
   # --ignore-installed six since jupyter tries to upgrade it, but it can't be
   # ugraded since it is a distutils package
-  - sudo pip3 install --ignore-installed six jupyter &> /dev/null
+  - sudo pip3 install --ignore-installed six jupyter jupyter_kernel_gateway &> /dev/null
   # Install the kernelspec using the right python. Jupyter installs a default
   # python kernelspec that uses "python" for the command in
   # /usr/local/share/jupyter. This installs one with an absolute path using our

--- a/README.org
+++ b/README.org
@@ -570,6 +570,23 @@ If =:session= is a remote file name that doesn't end in =.json=, e.g.
 the =jupyter kernel= command on the host. The local part of the session name
 serves to distinguish different remote sessions on the same host.
 
+*** Communicating with kernel (notebook) servers
+
+If =:session= has the form of a url, =http://HOST:PORT:name= or
+=http://HOST:name=, =HOST[:PORT]= is assumed to be a kernel server that can be
+communicated with using the Jupyter REST API and a kernel with a kernelspec
+name matching the =:kernel= header argument will be used to communicate with
+the server. Note, =name= is just used as an identifier for the session in
+=org-mode= and serves no other purpose, but is required to distinguish
+sessions.
+
+Alternatively, to connect to a kernel behind a kernel server, =:session= can
+look like =http://HOST:PORT/KERNEL-ID= or =http://HOST/KERNEL-ID= where
+=KERNEL-ID= is the ID of the kernel on the server. In this case, =:session=
+represents a connection to the kernel with =KERNEL-ID= on the server. Note, in
+this case the kernel must have been started with a kernelspec that matches the
+=:kernel= header argument.
+
 *** TODO Standard output, displayed data, and code block results
 
 One significant difference between Jupyter code blocks and regular =org-mode=

--- a/jupyter-client.el
+++ b/jupyter-client.el
@@ -229,7 +229,7 @@ See `jupyter-initialize-connection'."
               (list info-or-session
                     '(or jupyter-session-p json-plist-p stringp))))))
 
-;; NOTE: This requires that CLIENT is communicating with a kernel using a
+;; FIXME: This requires that CLIENT is communicating with a kernel using a
 ;; `jupyter-channel-ioloop-comm' object.
 (cl-defmethod jupyter-initialize-connection ((client jupyter-kernel-client) info-or-session)
   "Initialize CLIENT with connection INFO-OR-SESSION.
@@ -1773,7 +1773,10 @@ dispatching based on the kernel language."
       (let* ((jupyter-inhibit-handlers t)
              (req (jupyter-send-kernel-info-request client))
              (msg (jupyter-wait-until-received :kernel-info-reply
-                    req jupyter-long-timeout "Requesting kernel info...")))
+                    ;; Go to great lengths to ensure we have waited long
+                    ;; enough. When communicating with slow to start kernels
+                    ;; behind a kernel server this is necessary.
+                    req (* 3 jupyter-long-timeout) "Requesting kernel info...")))
         (unless msg
           (error "Kernel did not respond to kernel-info request"))
         (prog1 (oset client kernel-info (jupyter-message-content msg))

--- a/jupyter-kernel-manager.el
+++ b/jupyter-kernel-manager.el
@@ -260,6 +260,9 @@ argument of the process."
         (unless (memq system-type '(ms-dos windows-nt cygwin))
           (jupyter--block-until-conn-file-access atime kernel conn-file))))))
 
+;; TODO: Move to generalize the kernel manager even more so it is independent
+;; of a control channel and only relies mainly on the kernel and possibly some
+;; other general object that can also be a control channel.
 (defclass jupyter-kernel-manager (jupyter-kernel-lifetime)
   ((kernel
     :type jupyter-meta-kernel
@@ -334,7 +337,7 @@ connect to MANAGER's kernel."
     (jupyter-stop-channel channel)
     (oset manager control-channel nil)))
 
-(cl-defgeneric jupyter-shutdown-kernel ((manager jupyter-kernel-manager) &optional restart timeout)
+(cl-defgeneric jupyter-shutdown-kernel ((manager jupyter-kernel-manager) &rest args)
   "Shutdown MANAGER's kernel or restart instead if RESTART is non-nil.
 Wait until TIMEOUT before forcibly shutting down the kernel.")
 
@@ -372,7 +375,7 @@ channel is stopped unless RESTART is non-nil."
           (jupyter-start-kernel manager)
         (jupyter-stop-channels manager)))))
 
-(cl-defgeneric jupyter-interrupt-kernel ((manager jupyter-kernel-manager) &optional timeout)
+(cl-defgeneric jupyter-interrupt-kernel ((manager jupyter-kernel-manager) &rest args)
   "Interrupt MANAGER's kernel.
 When the kernel has an interrupt mode of \"message\" send an
 interrupt request and wait until TIMEOUT for a reply.")

--- a/jupyter-kernelspec.el
+++ b/jupyter-kernelspec.el
@@ -90,7 +90,7 @@ REFRESH has the same meaning as in
 `jupyter-available-kernelspecs'."
   (cdr (assoc name (jupyter-available-kernelspecs refresh))))
 
-(defun jupyter-find-kernelspecs (re &optional refresh)
+(defun jupyter-find-kernelspecs (re &optional specs refresh)
   "Find all specs of kernels that have names matching matching RE.
 RE is a regular expression use to match the name of a kernel.
 Return an alist with elements of the form:
@@ -104,13 +104,17 @@ resource directory.
 
 Optional argument REFRESH has the same meaning as in
 `jupyter-available-kernelspecs'."
-  (delq nil (mapcar (lambda (s) (and (string-match-p re (car s)) s))
-               (jupyter-available-kernelspecs refresh))))
+  (cl-remove-if-not
+   (lambda (s) (string-match-p re (car s)))
+   (or specs (jupyter-available-kernelspecs refresh))))
 
-(defun jupyter-guess-kernelspec (name)
+(defun jupyter-guess-kernelspec (name &optional specs refresh)
   "Return the first kernelspec matching NAME.
-Raise an error if no kernelspec could be found."
-  (or (car (jupyter-find-kernelspecs name))
+Raise an error if no kernelspec could be found.
+
+SPECS and REFRESH have the same meaning as in
+`jupyter-find-kernelspecs'."
+  (or (car (jupyter-find-kernelspecs name specs refresh))
       (error "No valid kernelspec for kernel name (%s)" name)))
 
 (defun jupyter-completing-read-kernelspec (&optional specs refresh)

--- a/jupyter-messages.el
+++ b/jupyter-messages.el
@@ -209,6 +209,41 @@ The returned object has the same form as the object returned by
   "Encode TIME into an ISO 8601 time string."
   (format-time-string "%FT%T.%6N" time t))
 
+(cl-defun jupyter-encode-raw-message (session
+                                      type
+                                      &rest plist
+                                      &key
+                                      content
+                                      (msg-id (jupyter-new-uuid))
+                                      parent-header
+                                      metadata
+                                      buffers
+                                      &allow-other-keys)
+  "Encode a message into a JSON string.
+Similar to `jupyter-encode-message', but returns the JSON encoded
+string instead of a list of the encoded parts.
+
+PLIST is an extra property list added to the top level of the
+message before encoding."
+  (declare (indent 2))
+  (cl-check-type session jupyter-session)
+  (cl-check-type metadata json-plist)
+  (cl-check-type content json-plist)
+  (cl-check-type parent-header json-plist)
+  (cl-check-type buffers list)
+  (or content (setq content jupyter--empty-dict))
+  (or parent-header (setq parent-header jupyter--empty-dict))
+  (or metadata (setq metadata jupyter--empty-dict))
+  (or buffers (setq buffers []))
+  (jupyter--encode
+   (cl-list*
+    :parent_header parent-header
+    :header (jupyter--message-header session type msg-id)
+    :content content
+    :metadata metadata
+    :buffers buffers
+    plist)))
+
 (cl-defun jupyter-encode-message (session
                                   type
                                   &key idents

--- a/jupyter-rest-api.el
+++ b/jupyter-rest-api.el
@@ -1,0 +1,449 @@
+;;; jupyter-rest-api.el --- Jupyter REST API -*- lexical-binding: t -*-
+
+;; Copyright (C) 2019 Nathaniel Nicandro
+
+;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
+;; Created: 03 Apr 2019
+;; Version: 0.7.3
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 2, or (at
+;; your option) any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; Commentary:
+
+;; Routines for working with the Jupyter REST API. Currently only the
+;; api/kernels and api/kernelspecs endpoints are implemented.
+
+;;; Code:
+
+(eval-when-compile (require 'subr-x))
+(require 'jupyter-base)
+(require 'websocket)
+
+(defgroup jupyter-rest-api nil
+  "Jupyter REST API"
+  :group 'jupyter)
+
+(defmacro jupyter-with-api (client &rest body)
+  "Bind `jupyter-api-url' to the url slot of CLIENT, evaluate BODY."
+  (declare (indent 1))
+  `(let ((jupyter-api-url (oref ,client url)))
+     ,@body))
+
+(defvar jupyter-api-url nil
+  "The URL used for requests by `jupyter-api--request'.")
+
+(defvar jupyter-api-max-authentication-attempts 3
+  "Maximum number of retries used for authentication.
+When attempting to authenticate a request, try this many times
+before raising an error.")
+
+;;; Jupyter REST API
+
+(defvar url-http-end-of-headers)
+(defvar url-http-response-status)
+(defvar gnutls-verify-error)
+
+(defclass jupyter-rest-client ()
+  ;; convert to a url field to avoid parsing this every time
+  ((url
+    :type string
+    :initform "http://localhost:8888"
+    :initarg :url)
+   (ws-url
+    :type string
+    :initarg :ws-url
+    :documentation "The WebSocket url to use.
+
+If this slot is not bound when initializing an instance of this
+class, it defaults to the value of the URL slot with the \"http\"
+prefix replaced by \"ws\". ")
+   (auth
+    :initarg :auth
+    :initform 'ask
+    :documentation "Indicator for authentication.
+
+If the symbol ask, ask the user how to authenticate requests to
+URL.
+
+If a list, then its assumed to be a list of cons cells that are
+the necessary HTTP headers used to authenticate requests and will
+be passed along with every request made.
+
+If the symbol password, ask for a login password to use.
+
+If the symbol token, ask for a token to use.
+
+If any other value, assume no steps are necessary to authenticate
+requests.")))
+
+(cl-defmethod initialize-instance ((client jupyter-rest-client) &optional _slots)
+  "Set CLIENT's WS-URL slot if it isn't bound.
+WS-URL will be a copy of URL with the url type equal to either ws
+or wss depending on if URL has a type of http or https,
+respectively."
+  (cl-call-next-method)
+  (unless (slot-boundp client 'ws-url)
+    (let ((url (url-generic-parse-url (oref client url))))
+      (setf (url-type url) (if (equal (url-type url) "https") "wss" "ws"))
+      (oset client ws-url (url-recreate-url url)))))
+
+;;; Authentication
+
+(defvar jupyter-api--auth-in-progress-p nil
+  "Let bound in `jupyter-api--authenticate'.")
+
+;; TODO: Be more efficient by working with url objects directly
+
+;; For more info on the XSRF header see
+;; https://blog.jupyter.org/security-release-jupyter-notebook-4-3-1-808e1f3bb5e2
+;; and
+;; http://www.tornadoweb.org/en/stable/guide/security.html#cross-site-request-forgery-protection
+(defun jupyter-api--xsrf-header (url)
+  (let ((url (url-generic-parse-url url)))
+    (cl-loop for cookie in (url-cookie-retrieve (url-host url) "/" nil)
+             if (equal (url-cookie-name cookie) "_xsrf")
+             return (list (cons "X-XSRFTOKEN" (url-cookie-value cookie))))))
+
+(defun jupyter-api--copy-cookies (url)
+  "Copy URL cookies so that those under HOST are accessible under HOST:PORT.
+`url-retrieve-synchronously' will store cookies under HOST
+whereas `websocket-open' will expect those cookies to be under
+HOST:PORT if PORT is a nonstandard port for the type of URL.
+
+The behavior of `url-retrieve-synchronously' (cookies being
+stored without considering a PORT) appears to be the standard,
+see RFC 6265."
+  (when-let* ((url (url-generic-parse-url url))
+              (host (url-host url))
+              (port (url-port-if-non-default url))
+              (host-port (format "%s:%s" host port)))
+    (cl-loop
+     for cookie in (url-cookie-retrieve host "/")
+     do (pcase-let (((cl-struct url-cookie name value expires
+                                localpart secure)
+                     cookie))
+          (url-cookie-store name value expires host-port localpart secure)))))
+
+(defun jupyter-api--password-login (client &optional empty-pw)
+  "Login to Jupyter server using CLIENT.
+This function attempts to login to the server located at CLIENT's
+url slot by using a password and raises an error if it cannot do
+so.
+
+On success, return a non-nil value. Note, when successful the
+necessary cookies will be used to authenticate requests when
+`jupyter-api-request' is called.
+
+If EMPTY-PW is on-nil, don't ask the user for a password just use
+an empty string as the password. This is mainly used to set the
+_xsrf cookie on password-less logins."
+  (let* ((url (oref client url))
+         (xsrf (jupyter-api--xsrf-header url))
+         (url-request-method "POST")
+         (url-request-extra-headers
+          (append xsrf
+                  (list (cons "Content-Type"
+                              "application/x-www-form-urlencoded"))
+                  url-request-extra-headers))
+         (pw (if empty-pw "" (read-passwd (format "Password [%s]: " url))))
+         (url-request-data (concat "password=" pw)))
+    (unwind-protect
+        (let* ((status nil)
+               (done nil)
+               (cb (lambda (s &rest _) (setq status s done t)))
+               (buffer (url-retrieve (concat url "/login") cb nil t)))
+          (jupyter-with-timeout
+              (nil jupyter-long-timeout
+                   (error "Timeout when logging in"))
+            done)
+          (let ((err (plist-get status :error)))
+            (unless (or (not err)
+                        ;; Handle unauthorized request that set the XSRF cookie
+                        (and (not xsrf)
+                             (= (nth 2 err) 403)
+                             (jupyter-api--xsrf-header url))
+                        ;; Handle HTTP 1.0. When given a POST request, 302
+                        ;; redirection doesn't change the method to GET
+                        ;; dynamically. On the Jupyter notebook, the redirected
+                        ;; page expects a GET and will return 405 (invalid
+                        ;; method).
+                        (with-current-buffer buffer
+                          (and (plist-get status :redirect)
+                               (= url-http-response-status 302)
+                               (= (nth 2 err) 405))))
+              (signal (car err) (cdr err))))
+          ;; Ensure that the cookies are written so that the communication
+          ;; subprocesses have access to them.
+          (jupyter-api--copy-cookies url)
+          (url-cookie-write-file)
+          t)
+      (clear-string url-request-data)
+      (clear-string pw))))
+
+(defun jupyter-api--authenticate (client &optional retries)
+  "Ensure requests using CLIENT are authenticated.
+Allow up to RETRIES attempts at authenticating, defaulting to
+`jupyter-api-max-authentication-attempts'.
+
+See the documentation of a `jupyter-rest-client's AUTH slot for
+more details."
+  (unless jupyter-api--auth-in-progress-p
+    (cl-check-type client jupyter-rest-client)
+    (or (numberp retries) (setq retries jupyter-api-max-authentication-attempts))
+    (when (zerop retries)
+      (error "Maximum number of authentication tries reached"))
+    (with-slots (auth url) client
+      (let ((jupyter-api--auth-in-progress-p t))
+        (pcase auth
+          ((guard (or (listp auth)
+                      (not (memq auth '(ask token password)))))
+           t)
+          ('ask
+           (cond
+            ;; Check to see if we don't need to ask, e.g. when the cookies are
+            ;; already set.
+            ((ignore-errors (jupyter-api-get-kernelspec client))
+             ;; Get the _xsrf cookies if we don't have them already.
+             (unless (jupyter-api--xsrf-header (oref client url))
+               (jupyter-api--password-login client t))
+             (oset client auth t))
+            (t
+             (cond
+              ((y-or-n-p (format "Token authenticated [%s]? " url))
+               (oset client auth 'token)
+               (jupyter-api--authenticate client retries))
+              ((y-or-n-p (format "Password needed [%s]? " url))
+               (oset client auth 'password)
+               (jupyter-api--authenticate client retries))
+              (t (oset client auth t))))))
+          ('token
+           (let ((token (read-string "Token: ")))
+             (oset client auth (list (cons "Authorization" (concat "token " token))))
+             (unless (ignore-errors (jupyter-api-get-kernelspec client))
+               (oset client auth 'token)
+               (jupyter-api--authenticate client (1- retries)))))
+          ('password
+           (if (ignore-errors (jupyter-api--password-login client))
+               (oset client auth t)
+             (jupyter-api--authenticate client (1- retries)))))))))
+
+(defun jupyter-api-http-request (url endpoint method &rest data)
+  "Send request to URL/ENDPOINT using HTTP METHOD.
+DATA is encoded into a JSON string using `json-encode' and sent
+as the HTTP request data. If DATA is nil, don't send any
+request data."
+  (declare (indent 3))
+  (let* ((url-request-method method)
+         (url-request-data (or (and data (json-encode data))
+                               url-request-data))
+         (url-request-extra-headers
+          (append (when data
+                    (list (cons "Content Type" "application/json")))
+                  url-request-extra-headers))
+         ;; Prevent the connection if security checks fail
+         (gnutls-verify-error t))
+    (with-current-buffer (url-retrieve-synchronously
+                          (concat url "/" endpoint)
+                          t nil jupyter-long-timeout)
+      (jupyter-api--copy-cookies url)
+      (goto-char url-http-end-of-headers)
+      (skip-syntax-forward "->")
+      (unless (eobp)
+        (let* ((json-object-type 'plist)
+               (resp (ignore-errors (json-read))))
+          (cond
+           ((>= url-http-response-status 400)
+            (cl-destructuring-bind
+                (&key reason message traceback &allow-other-keys) resp
+              (if traceback
+                  (error "%s (%s): %s" reason message
+                         (car (last (split-string traceback "\n" 'omitnulls))))
+                (and reason (setq reason (concat reason ": ")))
+                (if message (error "%s" (concat reason message))
+                  (error "Bad Response %s" url-http-response-status)))))
+           (t
+            resp)))))))
+
+;;; Calling the REST API
+
+(defun jupyter-api--request (method &rest plist)
+  "Send an HTTP request to `jupyter-api-url'.
+METHOD is the HTTP request method and PLIST contains the request.
+The elements of PLIST before the first keyword form the REST api
+endpoint and the rest of the PLIST after will be encoded into a
+JSON object and sent as the request data if METHOD is POST. So a
+call like
+
+    \(let ((jupyter-api-url \"http://localhost:8888\"))
+       (jupyter-api--request \"POST\" \"kernels\" :name \"python\"))
+
+will create an http POST request to the url
+http://localhost:8888/api/kernels using the JSON encoded from the
+plist (:name \"python\") as the POST data.
+
+As a special case, if METHOD is \"WS\", a websocket will be
+opened using the REST api url and PLIST will be used in a call to
+`websocket-open'."
+  (let (endpoint)
+    (while (and plist (not (or (keywordp (car plist))
+                               (null (car plist)))))
+      (push (pop plist) endpoint))
+    (setq endpoint (nreverse endpoint))
+    (cl-assert (not (null endpoint)))
+    (cl-assert (not (null jupyter-api-url)))
+    (setq endpoint (mapconcat #'identity (cons "api" endpoint) "/"))
+    (pcase method
+      ("WS"
+       (jupyter-api--copy-cookies jupyter-api-url)
+       (apply #'websocket-open
+              (concat jupyter-api-url "/" endpoint)
+              plist))
+      (_
+       (apply #'jupyter-api-http-request
+              jupyter-api-url endpoint method
+              plist)))))
+
+(cl-defgeneric jupyter-api-request ((client jupyter-rest-client) method &rest plist)
+  (declare (indent 2)))
+
+(cl-defmethod jupyter-api-request ((client jupyter-rest-client) method &rest plist)
+  "Send an HTTP request using CLIENT.
+METHOD is the HTTP request method and PLIST contains the request.
+The elements of PLIST before the first keyword form the REST api
+endpoint and the rest of the PLIST after will be encoded into a
+JSON object and sent as the request data. So a call like
+
+   \(jupyter-api-request client \"POST\" \"kernels\" :name \"python\")
+
+where the url slot of client is http://localhost:8888 will create
+an http POST request to the url http://localhost:8888/api/kernels
+using the JSON encoded from the plist (:name \"python\") as the
+POST data.
+
+Note an empty plist (after forming the endpoint) is interpreted
+as no request data at all and NOT as an empty JSON dictionary.
+
+As a special case, if METHOD is \"WS\", a websocket will be
+opened using the REST api url and PLIST will be used in a call to
+`websocket-open'."
+  (jupyter-api--authenticate client)
+  (let* ((xsrf (jupyter-api--xsrf-header (oref client url)))
+         (url-request-extra-headers url-request-extra-headers)
+         (jupyter-api-url
+          (slot-value
+           client
+           (pcase method
+             ("WS"
+              (prog1 'ws-url
+                (let ((head plist))
+                  (while (and head (not (keywordp (car head))))
+                    (pop head))
+                  (setq head (or (plist-member head :custom-header-alist)
+                                 (setcdr (last plist)
+                                         (list :custom-header-alist nil))))
+                  (let ((cur (plist-get head :custom-header-alist)))
+                    (plist-put head :custom-header-alist
+                               (append xsrf
+                                       (jupyter-api-auth-headers client)
+                                       cur))))))
+             (_
+              (prog1 'url
+                (cl-callf2 append
+                    (append xsrf (jupyter-api-auth-headers client))
+                    url-request-extra-headers)))))))
+    (apply #'jupyter-api--request method plist)))
+
+(cl-defmethod jupyter-api/kernels ((client jupyter-rest-client) method &rest plist)
+  "Send an HTTP request to the api/kernels endpoint to CLIENT's url.
+METHOD is the HTTP method to use. PLIST has the same meaning as
+in `jupyter-api-request'."
+  (apply #'jupyter-api-request client method "kernels" plist))
+
+(cl-defmethod jupyter-api/kernelspecs ((client jupyter-rest-client) method &rest plist)
+  "Send an HTTP request to the api/kernelspecs endpoint of CLIENT.
+METHOD is the HTTP method to use. PLIST has the same meaning as
+in `jupyter-api-request'."
+  (apply #'jupyter-api-request client method "kernelspecs" plist))
+
+;;; Kernels API
+
+(defun jupyter-api-get-kernel (client &optional id)
+  "Send an HTTP request using CLIENT to return a plist of the kernel with ID.
+If ID is nil, return models for all kernels accessible via CLIENT."
+  (jupyter-api/kernels client "GET" id))
+
+(defun jupyter-api-start-kernel (client &optional name)
+  "Send an HTTP request using CLIENT to start a kernel with kernelspec NAME.
+If NAME is not provided use the default kernelspec."
+  (apply #'jupyter-api/kernels client "POST"
+         (when name (list :name name))))
+
+(defun jupyter-api-shutdown-kernel (client id)
+  "Send the HTTP request using CLIENT to shutdown a kernel with ID."
+  (jupyter-api/kernels client "DELETE" id))
+
+(defun jupyter-api-restart-kernel (client id)
+  "Send an HTTP request using CLIENT to restart a kernel with ID."
+  (jupyter-api/kernels client "POST" id "restart"))
+
+(defun jupyter-api-interrupt-kernel (client id)
+  "Send an HTTP request using CLIENT to interrupt a kernel with ID."
+  (jupyter-api/kernels client "POST" id "interrupt"))
+
+;;;; Kernel websocket
+
+(defun jupyter-api-kernel-ws (client id &rest plist)
+  "Return a websocket using CLIENT's ws-url slot.
+ID identifies the kernel to connect to, PLIST will be passed to
+the call to `websocket-open' to initialize the websocket.
+
+Note, ID is also stored as the `websocket-client-data' slot of
+the returned websocket."
+  (let ((ws (apply #'jupyter-api/kernels client "WS" id "channels" plist)))
+    (prog1 ws
+      (setf (websocket-client-data ws) id))))
+
+;;; Kernelspec API
+
+(defun jupyter-api-get-kernelspec (client &optional name)
+  "Send an HTTP request using CLIENT to get the kernelspec with NAME.
+If NAME is not provided, return a plist of all kernelspecs
+available via CLIENT."
+  (apply #'jupyter-api/kernelspecs client "GET"
+         (when name (list :name name))))
+
+;;; Shutdown/interrupt kernel
+
+(cl-defmethod jupyter-shutdown-kernel ((client jupyter-rest-client) kernel-id
+                                       &optional restart timeout)
+  "Send an HTTP request using CLIENT to shutdown the kernel with KERNEL-ID.
+Optionally RESTART the kernel. If TIMEOUT is provided, it is the
+timeout used for the HTTP request."
+  (let ((jupyter-long-timeout (or timeout jupyter-long-timeout)))
+    (if restart (jupyter-api-restart-kernel client kernel-id)
+      (jupyter-api-shutdown-kernel client kernel-id))))
+
+(cl-defmethod jupyter-interrupt-kernel ((client jupyter-rest-client) kernel-id
+                                        &optional timeout)
+  "Send an HTTP request using CLIENT to interrupt the kernel with KERNEL-ID.
+If TIMEOUT is provided, it is the timeout used for the HTTP
+request."
+  (let ((jupyter-long-timeout (or timeout jupyter-long-timeout)))
+    (jupyter-api-interrupt-kernel client kernel-id)))
+
+(provide 'jupyter-rest-api)
+
+;;; jupyter-rest-api.el ends here

--- a/jupyter-rest-api.el
+++ b/jupyter-rest-api.el
@@ -240,6 +240,14 @@ more details."
                (oset client auth t)
              (jupyter-api--authenticate client (1- retries)))))))))
 
+(defun jupyter-api-auth-headers (client)
+  "Return the HTTP headers CLIENT is using for authentication or nil."
+  (cl-check-type client jupyter-rest-client)
+  (jupyter-api--authenticate client)
+  (with-slots (auth) client
+    (when (listp auth)
+      auth)))
+
 (defun jupyter-api-http-request (url endpoint method &rest data)
   "Send request to URL/ENDPOINT using HTTP METHOD.
 DATA is encoded into a JSON string using `json-encode' and sent

--- a/jupyter-server-ioloop.el
+++ b/jupyter-server-ioloop.el
@@ -1,0 +1,223 @@
+;;; jupyter-server-ioloop.el --- Kernel server communication -*- lexical-binding: t -*-
+
+;; Copyright (C) 2019 Nathaniel Nicandro
+
+;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
+;; Created: 03 Apr 2019
+;; Version: 0.7.3
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 2, or (at
+;; your option) any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; Commentary:
+
+;; A `jupyter-server-ioloop' launches websocket connections in order to
+;; communicate with a kernel server via the Jupyter messaging protocol. You can
+;; tell the ioloop to establish a websocket connection to a particular kernel
+;; by sending a connect-channels event with the websocket URL and kernel ID.
+;;
+;;     (jupyter-send ioloop 'connect-channels "id")
+;;
+;; A connect-channels event will be emitted back to the parent process with the
+;; ID of the kernel in response.
+;;
+;; To stop a websocket connection, a disconnect-channels event can be sent,
+;; passing the kernel ID.
+;;
+;;     (jupyter-send ioloop 'disconnect-channels "id")
+;;
+;; A disconnect-channels event will also be emitted back to the parent process
+;; with the ID of the kernel.
+;;
+;; Finally, a `jupyter-server-ioloop' behaves as a `jupyter-channel-ioloop'
+;; when sent a `send' event and will send back `message' or `sent' events as a
+;; `jupyter-channel-ioloop' would. If you haven't guessed by now, these events
+;; will always have (or should have in the case of `send') the kernel ID
+;; as the first argument. So to send a message to a kernel:
+;;
+;;     (jupyter-send ioloop 'send "id" ...)
+;;
+;; And message or sent events will look like
+;;
+;;     (message "id" ...) or (sent "id" ...)
+
+;;; Code:
+
+(require 'jupyter-ioloop)
+(require 'jupyter-messages)
+(require 'jupyter-rest-api)
+(require 'websocket)
+
+(defvar jupyter-server-recvd-messages nil)
+(defvar jupyter-server-connected-kernels nil)
+(defvar jupyter-server-rest-client nil)
+(defvar jupyter-server-ws-headers nil)
+
+(defclass jupyter-server-ioloop (jupyter-ioloop)
+  ((ws-url
+    :type string
+    :initarg :ws-url
+    :documentation "The URL to connect websockets to.")
+   (ws-headers
+    :type (list-of cons)
+    :initform nil
+    :initarg :ws-headers
+    :documentation "Headers that will be passed to the websocket connections.
+Has the same format as `url-request-extra-headers'."))
+  :documentation "A `jupyter-ioloop' configured for communication using websockets.
+
+A websocket can be opened by sending the connect-channels event
+with the websocket url and the kernel-id of the kernel to connect
+to, e.g.
+
+    \(jupyter-send ioloop 'connect-channels \"kernel-id\")
+
+Also implemented is the send event which takes the same arguments
+as the send event of a `jupyter-channel-ioloop' except the
+kernel-id must be the first element, e.g.
+
+    \(jupyter-send ioloop 'send \"kernel-id\" ...)
+
+Events that are emitted to the parent process are the message
+event, also the same as the event in `jupyter-channel-ioloop'
+except with a kernel-id as the first element. And a
+disconnected-channels event that occurs whenever a websocket is
+closed, the event has the kernel-id of the associated with the
+websocket.")
+
+(cl-defmethod initialize-instance ((ioloop jupyter-server-ioloop) &optional _slots)
+  (cl-call-next-method)
+  (cl-callf append (oref ioloop setup)
+    `((push ,(file-name-directory (locate-library "websocket")) load-path)
+      (require 'jupyter-server-ioloop)
+      (require 'url)
+      (push 'jupyter-server-ioloop--recv-messages jupyter-ioloop-pre-hook)
+      (setq jupyter-server-ws-headers (quote ,(oref ioloop ws-headers))
+            jupyter-server-rest-client (jupyter-rest-client
+                                        :ws-url ,(oref ioloop ws-url)))
+      ;; Ensure cookies used for authentication are read and used by
+      ;; `websocket-open'
+      (url-do-setup)
+      (url-cookie-parse-file)))
+  (jupyter-server-ioloop-add-send-event ioloop)
+  (jupyter-server-ioloop-add-connect-channels-event ioloop)
+  (jupyter-server-ioloop-add-disconnect-channels-event ioloop))
+
+;;; Receiving messages on a websocket
+
+;; Added to `jupyter-ioloop-pre-hook'
+(defun jupyter-server-ioloop--recv-messages ()
+  ;; A negative value of seconds means to return immediately if there was
+  ;; nothing that could be read from subprocesses. See `Faccept_process_output'
+  ;; and `wait_reading_process_output'.
+  (accept-process-output nil -1)
+  (when jupyter-server-recvd-messages
+    (mapc (lambda (msg) (prin1 (cons 'message msg)))
+       (nreverse jupyter-server-recvd-messages))
+    (setq jupyter-server-recvd-messages nil)
+    (zmq-flush 'stdout)))
+
+(defun jupyter-server-ioloop--on-message (ws frame)
+  (condition-case err
+      (progn
+        (cl-assert (eq (websocket-frame-opcode frame) 'text))
+        (let* ((msg (jupyter-read-plist-from-string
+                     (websocket-frame-payload frame)))
+               (channel (intern (concat ":" (plist-get msg :channel))))
+               (msg-type (jupyter-message-type-as-keyword
+                          (jupyter-message-type msg)))
+               (parent-header (plist-get msg :parent_header)))
+          ;; Convert into keyword since that is what is expected
+          (plist-put msg :msg_type msg-type)
+          (plist-put parent-header :msg_type msg-type)
+          ;; websocket-client-data = kernel-id
+          (push (cons (websocket-client-data ws)
+                      ;; NOTE: The nil is the identity field expected by a
+                      ;; `jupyter-channel-ioloop', it is mimicked here.
+                      (cons channel (cons nil msg)))
+                jupyter-server-recvd-messages)))
+    (error
+     (zmq-prin1 (cons 'error (list (car err)
+                                   (format "%S" (cdr err))))))))
+
+(defun jupyter-server-ioloop--disconnect (ws)
+  (let ((kernel-id (websocket-client-data ws)))
+    (zmq-prin1 (list 'disconnected-channels kernel-id))
+    (cl-callf2 delq ws jupyter-server-connected-kernels)))
+
+(defun jupyter-server-ioloop--kernel-ws (kernel-id)
+  (cl-find-if
+   (lambda (ws) (equal kernel-id (websocket-client-data ws)))
+   jupyter-server-connected-kernels))
+
+;;; IOLoop events
+
+(defvar jupyter-server--dummy-session (jupyter-session :id ""))
+
+(defun jupyter-server-ioloop-add-send-event (ioloop)
+  (jupyter-ioloop-add-event
+      ioloop send (kernel-id channel msg-type msg msg-id)
+    (let ((ws (jupyter-server-ioloop--kernel-ws kernel-id)))
+      (unless ws
+        (error "Kernel with ID (%s) not connected" kernel-id))
+      (if (not (websocket-openp ws))
+          (jupyter-server-ioloop--disconnect ws)
+        (websocket-send-text
+         ws (jupyter-encode-raw-message
+                jupyter-server--dummy-session msg-type
+              :channel (substring (symbol-name channel) 1)
+              :msg-id msg-id
+              :content msg))
+        (list 'sent kernel-id channel msg-id)))))
+
+(defun jupyter-server-ioloop-add-connect-channels-event (ioloop)
+  (jupyter-ioloop-add-event ioloop connect-channels (kernel-id)
+    (let ((ws (jupyter-server-ioloop--kernel-ws kernel-id)))
+      (when (and ws (not (websocket-openp ws)))
+        ;; Delete the process if not already
+        (websocket-close ws)
+        (setq ws nil))
+      (unless ws
+        ;; NOTE: Authentication of the client happens in the parent process or
+        ;; through the Authorization header set in
+        ;; `jupyter-server-ws-headers'. In the case of the parent process
+        ;; doing the authentication, cookies are written to `url-cookie-file'
+        ;; and read from this subprocess by the websocket code.
+        (push
+         (jupyter-api-kernel-ws
+          jupyter-server-rest-client kernel-id
+          :on-close #'jupyter-server-ioloop--disconnect
+          :on-message #'jupyter-server-ioloop--on-message
+          :custom-header-alist jupyter-server-ws-headers)
+         jupyter-server-connected-kernels)))
+    ;; Ensure any pending messages are handled, since usually we synchronize on
+    ;; connect-channels events, we want this event to be the
+    ;; `jupyter-ioloop-last-event' so the waiting loop in the parent process
+    ;; can capture it.
+    (jupyter-server-ioloop--recv-messages)
+    (list 'connect-channels kernel-id)))
+
+(defun jupyter-server-ioloop-add-disconnect-channels-event (ioloop)
+  (jupyter-ioloop-add-event ioloop disconnect-channels (kernel-id)
+    (let ((ws (jupyter-server-ioloop--kernel-ws kernel-id)))
+      ;; See the note at the end of
+      ;; `jupyter-server-ioloop-add-connect-channels-event'
+      (jupyter-server-ioloop--recv-messages)
+      (if ws (websocket-close ws)
+        (list 'disconnect-channels kernel-id)))))
+
+(provide 'jupyter-server-ioloop)
+
+;;; jupyter-server-ioloop.el ends here

--- a/jupyter-server.el
+++ b/jupyter-server.el
@@ -336,6 +336,21 @@ see ‘jupyter-make-client’."
     (let ((client (jupyter-server--kernel-client server kernel client-class)))
       (list (oref client manager) client))))
 
+(defun jupyter-find-server (url &optional ws-url)
+  "Return a live `jupyter-server' that lives at URL.
+Finds a server that matches both URL and WS-URL. When WS-URL the
+default set by `jupyter-rest-client' is used.
+
+Return nil if no `jupyter-server' could be found."
+  (with-slots (url ws-url)
+      (apply #'make-instance 'jupyter-rest-client
+             (append (list :url url)
+                     (when ws-url (list :ws-url ws-url))))
+    (cl-loop for server in (jupyter-servers)
+             thereis (and (equal (oref server url) url)
+                          (equal (oref server ws-url) ws-url)
+                          server))))
+
 (defun jupyter-guess-server ()
   "Return an existing `jupyter-server' or return a new one."
   (let ((servers (jupyter-servers)))

--- a/jupyter-server.el
+++ b/jupyter-server.el
@@ -367,6 +367,28 @@ the same meaning as in `jupyter-run-repl'."
       (jupyter-server-start-new-kernel server kernel-name client-class)
     (jupyter-bootstrap-repl client repl-name associate-buffer display)))
 
+;;;###autoload
+(defun jupyter-connect-server-repl
+    (server kernel-id &optional repl-name associate-buffer client-class display)
+  "On SERVER, connect to the kernel with KERNEL-ID.
+REPL-NAME, ASSOCIATE-BUFFER, CLIENT-CLASS, and DISPLAY all have
+the same meaning as in `jupyter-connect-repl'."
+  (interactive
+   (let ((server (jupyter-guess-server)))
+     (list server
+           (plist-get (jupyter-completing-read-server-kernel server) :id)
+           (when current-prefix-arg
+             (read-string "REPL Name: "))
+           t nil t)))
+  (or client-class (setq client-class 'jupyter-repl-client))
+  (jupyter-error-if-not-client-class-p client-class 'jupyter-repl-client)
+  (let* ((spec-name (plist-get (jupyter-api-get-kernel server kernel-id) :name))
+         (kernel (jupyter-server-kernel
+                  :id kernel-id
+                  :spec (assoc spec-name (jupyter-server-kernelspecs server))))
+         (client (jupyter-server--kernel-client server kernel client-class)))
+    (jupyter-bootstrap-repl client repl-name associate-buffer display)))
+
 (provide 'jupyter-server)
 
 ;;; jupyter-server.el ends here

--- a/jupyter-server.el
+++ b/jupyter-server.el
@@ -1,0 +1,347 @@
+;;; jupyter-server.el --- Support for the Jupyter kernel servers -*- lexical-binding: t -*-
+
+;; Copyright (C) 2019 Nathaniel Nicandro
+
+;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
+;; Created: 02 Apr 2019
+;; Version: 0.8.0
+
+;; This program is free software; you can redistribute it and/or
+;; modify it under the terms of the GNU General Public License as
+;; published by the Free Software Foundation; either version 2, or (at
+;; your option) any later version.
+
+;; This program is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+;; General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+;; Boston, MA 02111-1307, USA.
+
+;;; Commentary:
+
+;; A `jupyter-server' communicates with a Jupyter kernel server (either the
+;; notebook or a kernel gateway) via the Jupyter REST API. Given the URL and
+;; Websocket URL for the server, the `jupyter-server' object can launch kernels
+;; using the function `jupyter-server-start-new-kernel'. The kernelspecs
+;; available on the server can be accessed by calling
+;; `jupyter-server-kernelspecs'.
+;;
+;; `jupyter-server-start-new-kernel' returns a list (KM KC) where KM is a
+;; `jupyter-server-kernel-manager' and KC is a kernel client that can
+;; communicate with the kernel managed by KM. `jupyter-server-kernel-manager'
+;; sends requests to the server using the `jupyter-server' object to manage the
+;; lifetime of the kernel and ensures that a websocket is opened so that kernel
+;; clients created using `jupyter-make-client' can communicate with the kernel.
+;;
+;; Communication with the channels of the kernels that are launched on the
+;; `jupyter-server' is established via a `jupyter-server-ioloop' which
+;; multiplexes the channels of all the kernel servers. The kernel ID the server
+;; associated with a kernel can then be used to filter messages for a
+;; particular kernel and to send messages to a kernel through the
+;; `jupyter-server-ioloop'.
+;;
+;; `jupyter-server-kernel-comm' is a `jupyter-comm-layer' that handles the
+;; communication of a client with a server kernel. The job of the
+;; `jupyter-server-kernel-comm' is to connect to the `jupyter-server's event
+;; stream and filter the messages to handle those of a particular kernel
+;; identified by kernel ID.
+
+;;; Code:
+
+(eval-when-compile (require 'subr-x))
+(require 'jupyter-repl)
+(require 'jupyter-rest-api)
+(require 'jupyter-kernel-manager)
+(require 'jupyter-comm-layer)
+(require 'jupyter-server-ioloop)
+
+(defgroup jupyter-server nil
+  "Support for the Jupyter kernel gateway"
+  :group 'jupyter)
+
+(defvar jupyter--servers nil)
+
+(defclass jupyter-server (jupyter-rest-client
+                          jupyter-ioloop-comm
+                          jupyter-instance-tracker)
+  ((tracking-symbol :initform 'jupyter--servers)
+   (kernelspecs
+    :type json-plist
+    :initform nil
+    :documentation "Kernelspecs for the kernels available behind this gateway.
+Access should be done through `jupyter-available-kernelspecs'.")))
+
+(defun jupyter-servers ()
+  "Return a list of all `jupyter-server's."
+  (jupyter-all-objects 'jupyter--servers))
+
+(cl-defmethod initialize-instance ((comm jupyter-server) &optional _slots)
+  (cl-call-next-method)
+  (oset comm ioloop (jupyter-server-ioloop
+                     :ws-url (oref comm ws-url)
+                     :ws-headers (jupyter-api-auth-headers comm))))
+
+;; TODO: Add the server as a slot
+(defclass jupyter-server-kernel (jupyter-meta-kernel)
+  ((id
+    :type string
+    :initarg :id
+    :documentation "The kernel ID.")))
+
+(cl-defmethod jupyter-kernel-alive-p ((kernel jupyter-server-kernel))
+  (slot-boundp kernel 'id))
+
+(cl-defmethod jupyter-start-kernel ((kernel jupyter-server-kernel) server &rest _ignore)
+  (cl-check-type server jupyter-server)
+  (with-slots (spec) kernel
+    (jupyter-server--verify-kernelspec server spec)
+    (cl-destructuring-bind (&key id &allow-other-keys)
+        (jupyter-api-start-kernel server (car spec))
+      (oset kernel id id))))
+
+(cl-defmethod jupyter-kill-kernel ((kernel jupyter-server-kernel))
+  (cl-call-next-method)
+  (slot-makeunbound kernel 'id))
+
+(defclass jupyter-server-kernel-comm (jupyter-comm-layer)
+  ((server :type jupyter-server :initarg :server)
+   (kernel :type jupyter-server-kernel :initarg :kernel)))
+
+;;; `jupyter-server' events
+
+;; TODO: Test this
+(cl-defmethod jupyter-event-handler ((comm jupyter-server)
+                                     (event (head disconnect-channels)))
+  (let ((kernel-id (cadr event)))
+    (jupyter-comm-client-loop comm client
+      (when (equal kernel-id (oref (oref client kernel) id))
+        (jupyter-disconnect-client comm client)))
+    (with-slots (ioloop) comm
+      (cl-callf2 remove kernel-id
+                 (process-get (oref ioloop process) :kernel-ids)))))
+
+(cl-defmethod jupyter-event-handler ((comm jupyter-server)
+                                     (event (head connect-channels)))
+  (let ((kernel-id (cadr event)))
+    (with-slots (ioloop) comm
+      (cl-callf append (process-get (oref ioloop process) :kernel-ids)
+        (list kernel-id)))))
+
+(cl-defmethod jupyter-event-handler ((comm jupyter-server) event)
+  "Send EVENT to all clients connected to COMM.
+Each client must have a KERNEL slot which, in turn, must have an
+ID slot. The second element of EVENT is expected to be a kernel
+ID. Send EVENT, with the kernel ID excluded, to a client whose
+kernel has a matching ID."
+  (let ((kernel-id (cadr event)))
+    (setq event (cons (car event) (cddr event)))
+    (jupyter-comm-client-loop comm client
+      (when (equal kernel-id (oref (oref client kernel) id))
+        (run-at-time 0 nil #'jupyter-event-handler client event)))))
+
+;;; `jupyter-server' methods
+
+(cl-defmethod jupyter-connect-client ((comm jupyter-server)
+                                      (kcomm jupyter-server-kernel-comm))
+  (with-slots (id) (oref kcomm kernel)
+    (cl-call-next-method)
+    (jupyter-send comm 'connect-channels id)
+    (unless (jupyter-ioloop-wait-until (oref comm ioloop)
+                'connect-channels #'identity)
+      (error "Timeout when connecting websocket to kernel id %s" id))))
+
+(cl-defmethod jupyter-server-kernel-connected-p ((comm jupyter-server) id)
+  "Return non-nil if COMM has a WebSocket connection to a kernel with ID."
+  (and (jupyter-comm-alive-p comm)
+       (member id (process-get (oref (oref comm ioloop) process) :kernel-ids))))
+
+(defun jupyter-server--verify-kernelspec (server spec)
+  (cl-destructuring-bind (name _ . kspec) spec
+    (let ((server-spec (assoc name (jupyter-server-kernelspecs server))))
+      (unless server-spec
+        (error "No kernelspec matching %s on server @ %s"
+               name (oref server url)))
+      (when (cl-loop
+             with sspec = (cddr server-spec)
+             for (k v) on sspec by #'cddr
+             thereis (not (equal (plist-get kspec k) v)))
+        (error "%s kernelspec doesn't match one on server @ %s"
+               name (oref server url))))))
+
+(cl-defmethod jupyter-server-kernelspecs ((server jupyter-server) &optional refresh)
+  "Return the kernelspecs on SERVER.
+By default the available kernelspecs are cached. To force an
+update of the cached kernelspecs, give a non-nil value to
+REFRESH.
+
+The kernelspecs are returned in the same form as returned by
+`jupyter-available-kernelspecs'."
+  (when (or refresh (null (oref server kernelspecs)))
+    (let ((specs (jupyter-api-get-kernelspec server)))
+      (unless specs
+        (error "Can't retrieve kernelspecs from server @ %s" (oref server url)))
+      (oset server kernelspecs specs)
+      (plist-put (oref server kernelspecs) :kernelspecs
+                 (cl-loop
+                  with specs = (plist-get specs :kernelspecs)
+                  for (_ spec) on specs by #'cddr
+                  ;; Uses the same format as `jupyter-available-kernelspecs'
+                  ;;     (name dir . spec)
+                  collect (cons (plist-get spec :name)
+                                (cons nil (plist-get spec :spec)))))))
+  (plist-get (oref server kernelspecs) :kernelspecs))
+
+;;; `jupyter-server-kernel-comm' methods
+
+(cl-defmethod jupyter-comm-start ((comm jupyter-server-kernel-comm) &rest _ignore)
+  "Register COMM to receive server events.
+If SERVER receives events that have the same kernel ID as the
+kernel associated with COMM, then COMM's `jupyter-event-handler'
+will receive those events."
+  (with-slots (server) comm
+    (jupyter-comm-start server)
+    (jupyter-connect-client server comm)))
+
+(cl-defmethod jupyter-comm-stop ((comm jupyter-server-kernel-comm) &rest _ignore)
+  "Disconnect COMM from receiving server events."
+  (jupyter-disconnect-client (oref comm server) comm))
+
+(cl-defmethod jupyter-send ((comm jupyter-server-kernel-comm) event-type &rest event)
+  "Use COMM to send an EVENT to the server with type, EVENT-TYPE.
+SERVER will direct EVENT to the right kernel based on the kernel
+ID of the kernel associated with COMM."
+  (with-slots (server kernel) comm
+    (apply #'jupyter-send server event-type (oref kernel id) event)))
+
+(cl-defmethod jupyter-comm-alive-p ((comm jupyter-server-kernel-comm))
+  "Return non-nil if COMM can receive server events for its associated kernel."
+  (and (jupyter-server-kernel-connected-p
+        (oref comm server)
+        (oref (oref comm kernel) id))
+       (catch 'member
+         (jupyter-comm-client-loop (oref comm server) client
+           (when (eq client comm)
+             (throw 'member t))))))
+
+;; TODO: Remove the need for these methods, they are remnants from an older
+;; implementation. They will need to be removed from `jupyter-kernel-client'.
+(cl-defmethod jupyter-channel-alive-p ((comm jupyter-server-kernel-comm) _channel)
+  (jupyter-comm-alive-p comm))
+
+(cl-defmethod jupyter-channels-running-p ((comm jupyter-server-kernel-comm))
+  (jupyter-comm-alive-p comm))
+
+;;; `jupyter-server-kernel-manager'
+
+;; TODO: Generalize `jupyter-kernel-manager' some more so that it can be
+;; sub-classed.
+(defclass jupyter-server-kernel-manager (jupyter-kernel-lifetime)
+  ((server :type jupyter-server :initarg :server)
+   (kernel :type jupyter-server-kernel :initarg :kernel)
+   (comm :type jupyter-server-kernel-comm)))
+
+(cl-defmethod jupyter-kernel-alive-p ((manager jupyter-server-kernel-manager))
+  (with-slots (server kernel) manager
+    (and (jupyter-kernel-alive-p kernel)
+         (ignore-errors (jupyter-api-get-kernel server (oref kernel id))))))
+
+(cl-defmethod jupyter-start-kernel ((manager jupyter-server-kernel-manager) &rest _ignore)
+  "Ensure that the gateway can receive events from its kernel."
+  (with-slots (server kernel) manager
+    (jupyter-start-kernel kernel server)))
+
+(cl-defmethod jupyter-kill-kernel ((manager jupyter-server-kernel-manager))
+  (jupyter-shutdown-kernel manager))
+
+(cl-defmethod jupyter-shutdown-kernel ((manager jupyter-server-kernel-manager) &rest _args)
+  (with-slots (server kernel comm) manager
+    (jupyter-api-shutdown-kernel server (oref kernel id))
+    (jupyter-comm-stop comm)))
+
+(cl-defmethod jupyter-make-client ((manager jupyter-server-kernel-manager) _class &rest _slots)
+  (let ((client (cl-call-next-method)))
+    (prog1 client
+      ;; TODO: What are the GC consequences
+      (unless (slot-boundp manager 'comm)
+        (oset manager comm (jupyter-server-kernel-comm
+                            :kernel (oref manager kernel)
+                            :server (oref manager server)))
+        (jupyter-comm-start (oref manager comm)))
+      (oset client kcomm (oref manager comm)))))
+
+;;; REPL
+
+(defun jupyter-server--kernel-client (server kernel client-class)
+  (let ((manager (jupyter-server-kernel-manager
+                  :server server :kernel kernel)))
+    (unless (jupyter-kernel-alive-p kernel)
+      (jupyter-start-kernel manager))
+    (let ((client (jupyter-make-client manager client-class)))
+      (jupyter-start-channels client)
+      client)))
+
+;; TODO: When closing the REPL buffer and it is the last connected client as
+;; shown by the :connections key of a `jupyter-api-get-kernel' call, ask to
+;; also shutdown the kernel.
+(defun jupyter-server-start-new-kernel (server kernel-name &optional client-class)
+  "Start a managed Jupyter kernel on SERVER.
+KERNEL-NAME is the name of the kernel to start. It can also be
+the prefix of a valid kernel name, in which case the first kernel
+in ‘jupyter-server-kernelspecs’ that has KERNEL-NAME as a
+prefix will be used.
+
+Optional argument CLIENT-CLASS is a subclass
+of ‘jupyer-kernel-client’ and will be used to initialize a new
+client connected to the kernel. CLIENT-CLASS defaults to the
+symbol ‘jupyter-kernel-client’.
+
+Return a list (KM KC) where KM is the kernel manager managing the
+lifetime of the kernel on SERVER. KC is a new client connected to
+the kernel whose class is CLIENT-CLASS. Note that the client’s
+‘manager’ slot will also be set to the kernel manager instance,
+see ‘jupyter-make-client’."
+  (or client-class (setq client-class 'jupyter-kernel-client))
+  (let* ((specs (jupyter-server-kernelspecs server))
+         (kernel (jupyter-server-kernel
+                  :spec (jupyter-guess-kernelspec kernel-name specs))))
+    (let ((client (jupyter-server--kernel-client server kernel client-class)))
+      (list (oref client manager) client))))
+
+(defun jupyter-guess-server ()
+  "Return an existing `jupyter-server' or return a new one."
+  (let ((servers (jupyter-servers)))
+    (if (> (length servers) 1)
+        (cdr (completing-read "Server: " (mapcar (lambda (x) (cons (oref x url) x))
+                                            servers)))
+      (or (car servers)
+          (let ((url (read-string "Server URL: " "http://localhost:8888"))
+                (ws-url (read-string "Websocket URL: " "ws://localhost:8888")))
+            (jupyter-server :url url :ws-url ws-url))))))
+
+;;;###autoload
+(defun jupyter-run-server-repl
+    (server kernel-name &optional repl-name associate-buffer client-class display)
+  "On SERVER start a kernel with KERNEL-NAME.
+REPL-NAME, ASSOCIATE-BUFFER, CLIENT-CLASS, and DISPLAY all have
+the same meaning as in `jupyter-run-repl'."
+  (interactive
+   (let ((server (jupyter-guess-server)))
+     (list server
+           (car (jupyter-completing-read-kernelspec
+                 (jupyter-server-kernelspecs server)))
+           (when current-prefix-arg
+             (read-string "REPL Name: "))
+           t nil t)))
+  (or client-class (setq client-class 'jupyter-repl-client))
+  (jupyter-error-if-not-client-class-p client-class 'jupyter-repl-client)
+  (cl-destructuring-bind (_manager client)
+      (jupyter-server-start-new-kernel server kernel-name client-class)
+    (jupyter-bootstrap-repl client repl-name associate-buffer display)))
+
+(provide 'jupyter-server)
+
+;;; jupyter-server.el ends here

--- a/test/jupyter-test.el
+++ b/test/jupyter-test.el
@@ -1642,6 +1642,88 @@ last element being the newest element added to the history."
           (let ((kill-buffer-query-functions nil))
             (kill-buffer)))))))
 
+;;; REST API
+
+(ert-deftest jupyter-rest-api ()
+  :tags '(rest)
+  (let ((client (jupyter-rest-client
+                 :url "http://foo"
+                 :ws-url "ws://foo"
+                 :auth t)))
+    (jupyter-test-rest-api
+     (jupyter-api-request client "GET" "kernels")
+     (should (equal url "http://foo/api/kernels"))
+     (should (equal url-request-method "GET"))
+     (should (equal url-request-data nil))
+     (should (equal url-request-extra-headers nil)))
+    (jupyter-test-rest-api
+     (jupyter-api-request client "POST" "kernels" "ID" :name "bar")
+     (should (equal url "http://foo/api/kernels/ID"))
+     (should (equal url-request-method "POST"))
+     (should (equal url-request-data (json-encode '(:name "bar"))))
+     (should (equal (alist-get "Content Type" url-request-extra-headers nil nil #'equal)
+                    "application/json")))
+    (cl-letf (((symbol-function #'websocket-open)
+               (lambda (url &rest plist)
+                 (should (equal url "ws://foo/api/kernels"))
+                 (should (equal (plist-get plist :on-open) 'identity)))))
+      (jupyter-api-request client "WS" "kernels" :on-open 'identity))))
+
+(ert-deftest jupyter-api--copy-cookies ()
+  :tags '(rest)
+  (let (url-cookie-storage)
+    (url-cookie-store "_xsrf" "1" nil "localhost" "/")
+    (url-cookie-store "username-login-8888" "2" nil "localhost" "/")
+    (let ((old-cookies (url-cookie-retrieve "localhost" "/")) cookies)
+      (jupyter-api--copy-cookies "http://localhost:8888")
+      (should (setq cookies (url-cookie-retrieve "localhost:8888" "/")))
+      (cl-loop
+       for cookie in old-cookies
+       do (setf (url-cookie-domain cookie) "localhost:8888"))
+      (cl-loop
+       for cookie in cookies
+       ;; old-cookies now have the domain of the new cookies for verification
+       ;; purposes
+       do (should (member cookie old-cookies))))))
+
+(ert-deftest jupyter-api--password-login ()
+  (let (cookies-copied-before-write
+        cookies-written
+        url-cookie-storage)
+    (cl-letf (((symbol-function #'read-passwd)
+               (lambda (&rest _) "foo"))
+              ((symbol-function #'jupyter-api--copy-cookies)
+               (lambda (&rest _)
+                 (setq cookies-copied-before-write t)))
+              ((symbol-function #'url-cookie-write-file)
+               (lambda (&rest _)
+                 (should cookies-copied-before-write)
+                 (setq cookies-written t))))
+      (url-cookie-store "_xsrf" "1" nil "localhost" "/")
+      (jupyter-test-rest-api
+          (jupyter-api--password-login
+           (jupyter-rest-client :url "http://localhost:8888"))
+        (should (equal url-request-method "POST"))
+        (should (equal url "http://localhost:8888/login"))
+        (should (equal (cdr (assoc "X-XSRFTOKEN" url-request-extra-headers)) "1"))
+        (should (equal (cdr (assoc "Content-Type" url-request-extra-headers))
+                       "application/x-www-form-urlencoded"))
+        (should (equal url-request-data "password=foo"))))
+    (should cookies-written)))
+
+;; TODO
+(ert-deftest jupyter-api-kernel-ws ()
+  :tags '(rest)
+  (skip-unless nil)
+  (let ((client (jupyter-rest-client)))
+    (cl-destructuring-bind (&key id &allow-other-keys)
+        (jupyter-api-start-kernel client)
+      (unwind-protect
+          (let ((ws (jupyter-api-kernel-ws client id)))
+            (sleep-for 1)
+            (websocket-close ws))
+        (jupyter-api-shutdown-kernel client id)))))
+
 ;;; `org-mode'
 
 (defvar org-babel-jupyter-resource-directory nil)

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -100,7 +100,8 @@ handling a message is always
 
 ;;; `jupyter-mock-comm-layer'
 
-(defclass jupyter-mock-comm-layer (jupyter-comm-layer)
+(defclass jupyter-mock-comm-layer (jupyter-comm-layer
+                                   jupyter-comm-autostop)
   ((alive :initform nil)))
 
 (cl-defmethod jupyter-comm-alive-p ((comm jupyter-mock-comm-layer))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -238,6 +238,35 @@ running BODY."
   `(jupyter-test-with-kernel-repl "python" ,client
      ,@body))
 
+(defmacro jupyter-test-rest-api (bodyform &rest check-forms)
+  "Replace the body of `url-retrieve-synchronously' with CHECK-FORMS, evaluate BODYFORM.
+The body of `url-retrieve' is also replaced and calls
+CHECK-FORMS, then calls the callback function with a nil status."
+  (declare (indent 1))
+  `(progn
+     (defvar url-request-data)
+     (defvar url-request-method)
+     (defvar url-request-extra-headers)
+     (defvar url-http-end-of-headers)
+     (defvar url-http-response-status)
+     (let (url-request-data
+           url-request-method
+           url-request-extra-headers
+           url-http-end-of-headers
+           (url-http-response-status 200)
+           (fun (lambda (url &rest _)
+                  (setq url-http-end-of-headers (point-min))
+                  ,@check-forms
+                  (current-buffer))))
+       (with-temp-buffer
+         (cl-letf (((symbol-function #'url-retrieve-synchronously) fun)
+                   ((symbol-function #'url-retrieve)
+                    (lambda (url cb &optional cbargs &rest _)
+                      (prog1
+                          (funcall fun url)
+                        (apply cb nil cbargs)))))
+           ,bodyform)))))
+
 ;;; Functions
 
 (defun jupyter-test-ipython-kernel-version (spec)


### PR DESCRIPTION
This adds support for the Jupyter notebook server `kernel` and `kernelspecs` API endpoints (https://github.com/jupyter/jupyter/wiki/Jupyter-Notebook-Server-API). Currently tested using the `jupyter_kernel_gateway`, but should also work for notebooks.

TODO:

- [x] HTTP authentication
   - Currently only tested on a local HTTP connection
- [ ] Use `jupyter-add-finalizer` in more places to ensure all resources are cleaned up properly.
- [x] Allow connecting to a kernel server using the `:session` argument in `org-mode` source blocks
  - See the `Communicating with kernel (notebook) servers` README section

Closes #74 