### PR TITLE
Echo evaluation in REPL (fixes #71)

### DIFF
--- a/jupyter-client.el
+++ b/jupyter-client.el
@@ -1076,6 +1076,9 @@ restore its position after evaluation."
       (save-excursion
         (goto-char (point-max))
         (jupyter-repl-insert str)
+        ;; extra newline needed for some special cases
+        ;; (e.g., Python defun's that end in EOF)
+        (jupyter-repl-insert "\n")
         (jupyter-repl-ret))
       (when point-at-max
         (goto-char (point-max))))))

--- a/jupyter-client.el
+++ b/jupyter-client.el
@@ -1074,11 +1074,11 @@ restore its position after evaluation."
   (jupyter-with-repl-buffer jupyter-current-client
     (let ((point-at-max (eql (point) (point-max))))
       (save-excursion
-        (end-of-buffer)
+        (goto-char (point-max))
         (jupyter-repl-insert str)
         (jupyter-repl-ret))
       (when point-at-max
-        (end-of-buffer)))))
+        (goto-char (point-max))))))
 
 (defun jupyter-send-to-repl-defun ()
   "Paste the current function in the repl and evaluate it there."


### PR DESCRIPTION
This PR provides ESS/comint-style alternatives to `jupyter-eval-*`, that paste input/output in the REPL buffer, instead of displaying output  through a message or pop-up buffer.

Here's a screenshot:
![jupyter-send-to-repl](https://user-images.githubusercontent.com/9089216/57976753-6a7dd000-799c-11e9-8f5d-a575072c4177.gif)

For now, I've made `jupyter-send-to-repl-*` as separate functions from `jupyter-eval-*`, because that was the simplest to implement. Here's some options about what to do next:

0) Keep things as is, just add some keybindings for the new functions, and mention them in the Readme.
1) Make this behavior an option of `jupyter-eval-*` instead of creating separate functions.  The option could be set by user customization, or some other way (prefix-key? window arrangement?)
2)  Instead of separate functions, make `jupyter-eval-*` send output to **both** a pop-up buffer and the REPL at the same time.
    - Note: I initially tried going this route, using `jupyter-repl-insert` and `jupyter-repl-insert-prompt` to print the Input and a subsequent prompt, but printing the Output back to its associated cell seems trickier -- I remember getting an error about not being able to find the appropriate cell when I tried to use `jupyter-repl-append-output` just above this line: https://github.com/dzop/emacs-jupyter/blob/111d105b51e53bd254bdb59cb9d3fda1352c948a/jupyter-client.el#L974 I'll reproduce the specific error message if we decide it's better to go this route.