### PR TITLE
jupyter-org-client.el: Add `org-table` mime type

### DIFF
--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -963,6 +963,8 @@ passed to Jupyter org-mode source blocks."
 
 (cl-defmethod jupyter-org-result ((_mime (eql :text/org)) _params data
                                   &optional _metadata)
+  (when (string-match-p org-table-line-regexp data)
+    (put-text-property 0 1 'org-table t data))
   (jupyter-org-raw-string data))
 
 (cl-defmethod jupyter-org-result ((mime (eql :image/png)) params data


### PR DESCRIPTION
This allows for better integration with backends that can generate org-format tables.

For example, when using `tabulate` to format pandas DataFrames as described [here](https://github.com/gregsexton/ob-ipython/blob/7147455230841744fb5b95dcbe03320313a77124/README.org#tips-and-tricks), results are inserted in a drawer, in accordance with the `text/org` mime type.

```
#+begin_src jupyter-python :session test :display org
  import numpy as np
  import pandas as pd

  np.random.seed(123)
  df = pd.DataFrame({'a': np.random.normal(1, 1, 5), 
		     'b': np.random.normal(5, 5, 5)})
  df.rename_axis('id', inplace=True)
  df
#+end_src

#+name: table1
#+results:
:RESULTS:
|   id |          a |         b |
|------+------------+-----------|
|    0 | -0.0856306 | 13.2572   |
|    1 |  1.99735   | -7.1334   |
|    2 |  1.28298   |  2.85544  |
|    3 | -0.506295  | 11.3297   |
|    4 |  0.4214    |  0.666298 |
:END:
```

This is fine, but given org knows how to handle tables the results drawer is redundant.

Also, the drawer breaks referencing.

```
#+header: :var data=table1 :colnames no
#+begin_src jupyter-python :session test
  data         # org-babel-ref-resolve: Reference not found
#+end_src
```

~~Having a special mime type `text/org-table`, and a corresponding formatter (e.g. initialised in `~/.ipython/profile_default/startup/`), would solve this.~~

Checking if the returned string is a table allows us to treat it as such.

``` python
import IPython
import numpy as np
import pandas as pd
import tabulate as tab


class OrgFormatter(IPython.core.formatters.BaseFormatter):
    def __call__(self, obj):
        if type(obj) is pd.Series:
            obj = obj.to_frame()
        if isinstance(obj, (pd.DataFrame, np.ndarray, np.recarray)):
            try:
                return tab.tabulate(obj, headers='keys',
                                    tablefmt='orgtbl', showindex='always')
            except Exception as e:
                print(e)
                return None


ip = get_ipython()
ip.display_formatter.formatters['text/org'] = OrgFormatter()
```

Tables are now inserted without a drawer. All other (non-table) strings will still be inserted within a drawer.

```
#+begin_src jupyter-python :session test :display org-table
  import numpy as np
  import pandas as pd

  np.random.seed(123)
  df = pd.DataFrame({'a': np.random.normal(1, 1, 5), 
		     'b': np.random.normal(5, 5, 5)})
  df.rename_axis('id', inplace=True)
  df
#+end_src

#+name: table2
#+results:
| id |          a |        b |
|----+------------+----------|
|  0 | -0.0856306 |  13.2572 |
|  1 |    1.99735 |  -7.1334 |
|  2 |    1.28298 |  2.85544 |
|  3 |  -0.506295 |  11.3297 |
|  4 |     0.4214 | 0.666298 |
```

Referencing output tables now works again.

```
#+header: :var data=table2 :colnames no
#+begin_src jupyter-python :session test
  data
#+end_src

#+results:
| id |          a |        b |
|  0 | -0.0856306 |  13.2572 |
|  1 |    1.99735 |  -7.1334 |
|  2 |    1.28298 |  2.85544 |
|  3 |  -0.506295 |  11.3297 |
|  4 |     0.4214 | 0.666298 |
```