### PR TITLE
Add jupyter-org-adjust-image-size.

### DIFF
--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -73,6 +73,19 @@ automatically be shown if this is non-nil."
   :group 'ob-jupyter
   :type '(repeat string))
 
+(defcustom jupyter-org-adjust-image-size
+  t
+  "Try to best fit image output in the result block.
+
+If non-nil, and `org-image-actual-width' is set to a list, the
+image will not be stretched if its width is small than (car
+`org-image-actual-width'). This is done by inserting #+ATTR_ORG
+keyword above the file path.
+
+See the docstring of `org-image-actual-width' for more details."
+  :group 'ob-jupyter
+  :type 'boolean)
+
 (defconst jupyter-org-mime-types '(:text/org
                                    ;; Prioritize images over html
                                    :image/svg+xml :image/jpeg :image/png
@@ -868,6 +881,12 @@ the width or height of the image."
             (base64-decode-region (point-min) (point-max))))))
     (cl-destructuring-bind (&key width height &allow-other-keys)
         metadata
+      (if (and (null width)
+               jupyter-org-adjust-image-size
+               (listp org-image-actual-width))
+          (let ((image-width (car (image-size (create-image file) 'pixels))))
+            (if (< image-width (car org-image-actual-width))
+                (setq width image-width))))
       (jupyter-org-image-link file width height))))
 
 (cl-defgeneric jupyter-org-result (_mime _params _data &optional _metadata)

--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -78,7 +78,7 @@ automatically be shown if this is non-nil."
   "Try to best fit image output in the result block.
 
 If non-nil, and `org-image-actual-width' is set to a list, the
-image will not be stretched if its width is small than (car
+image will not be stretched if its width is smaller than (car
 `org-image-actual-width'). This is done by inserting #+ATTR_ORG
 keyword above the file path.
 

--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -79,7 +79,7 @@ automatically be shown if this is non-nil."
 
 If non-nil, and `org-image-actual-width' is set to a list, the
 image will not be stretched if its width is smaller than (car
-`org-image-actual-width'). This is done by inserting #+ATTR_ORG
+`org-image-actual-width'). This is done by inserting an #+ATTR_ORG
 keyword above the file path.
 
 See the docstring of `org-image-actual-width' for more details."

--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -82,7 +82,16 @@ image will not be stretched if its width is smaller than (car
 `org-image-actual-width'). This is done by inserting an #+ATTR_ORG
 keyword above the file path.
 
-See the docstring of `org-image-actual-width' for more details."
+The metadata of the returned image by the kernel maybe
+missing. In this case, setting `jupyter-org-adjust-image-size' to
+non-nil value means try to get the actual size of the image, i.e.
+
+(if (and (null width)                   ; no width info in metadata
+         jupyter-org-adjust-image-size
+         (listp org-image-actual-width))
+     ...)                               ; fetch image size
+
+See also the docstring of `org-image-actual-width' for more details."
   :group 'ob-jupyter
   :type 'boolean)
 


### PR DESCRIPTION
If the `org` block outputs an image, and `org-image-actual-width` is a `list`, this PR provides customization to not to stretch the image if its width is smaller than `(car org-image-actual-width)`.