### PR TITLE
Move whitespace to overlay prefix

### DIFF
--- a/jupyter-client.el
+++ b/jupyter-client.el
@@ -54,7 +54,7 @@ overlays at the end of the line if possible."
   :group 'jupyter-client
   :type 'boolean)
 
-(defcustom jupyter-eval-overlay-prefix "=>"
+(defcustom jupyter-eval-overlay-prefix "=> "
   "Evaluation result overlays will be prefixed with this string."
   :group 'jupyter-client
   :type 'string)
@@ -1242,7 +1242,7 @@ representation of the results in the current buffer."
                     ;; overlay.
                     (if newline " \n" " ")
                     (propertize
-                     (concat jupyter-eval-overlay-prefix " " text)
+                     (concat jupyter-eval-overlay-prefix text)
                      'face 'jupyter-eval-overlay))))
       ;; Ensure `point' doesn't move past the beginning or end of the overlay
       ;; on motion commands.


### PR DESCRIPTION
Move the whitespace that was originally concatenated to the prefix variable `jupyter-eval-overlay-prefix` to the variable itself, so that it can be easily customized. For instance, in the case where one does not want any prefix, with the changes, it can be easily removed by setting the prefix variable to the empty string. Originally one would have to also modify the function `jupyter-eval-ov--propertize` to achieve the same result.