### PR TITLE
fix: show pop-up buffer when REPL not visible

### DIFF
--- a/jupyter-repl.el
+++ b/jupyter-repl.el
@@ -1518,7 +1518,7 @@ value."
     ;; when BEG and END are non-nil.
     (prog1 req
       (unless (and jupyter-repl-echo-eval-p
-                   (get-buffer-window nil 'visible))
+                   (get-buffer-window (oref jupyter-current-client buffer) 'visible))
         (jupyter-eval-add-callbacks req beg end)))))
 
 ;;; Kernel management


### PR DESCRIPTION
The described behavior for when `jupyter-repl-echo-eval-p` is `t` and the REPL buffer is not visible was not working, i.e., no pop-up buffer was being show.