### PR TITLE
jupyter-repl-traceback face: use a light background on light themes

### DIFF
--- a/jupyter-repl.el
+++ b/jupyter-repl.el
@@ -90,7 +90,7 @@
 
 (defface jupyter-repl-traceback
   '((((class color) (min-colors 88) (background light))
-     :background "darkred")
+     :background "LightYellow2")
     (((class color) (min-colors 88) (background dark))
      :background "firebrick"))
   "Face used for a traceback."


### PR DESCRIPTION
The previous value of this face used a dark background even on light themes, making
error messages hard to read.

This is how the proposed new setting looks like on Emacs's default theme:

![image](https://user-images.githubusercontent.com/6500902/71965419-eebce600-31ff-11ea-9f67-78b03e3a4ad9.png)
