### PR TITLE
Clean header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ flycheck_*
 node_modules/
 *lock*
 built/
+.cask/

--- a/jupyter-R.el
+++ b/jupyter-R.el
@@ -2,7 +2,8 @@
 
 ;; Copyright (C) 2019 Nathaniel Nicandro
 
-;; Author: Jack Kamm <jackkamm@gmail.com>, Nathaniel Nicandro <nathanielnicandro@gmail.com>
+;; Author: Jack Kamm <jackkamm@gmail.com>
+;;         Nathaniel Nicandro <nathanielnicandro@gmail.com>
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-base.el
+++ b/jupyter-base.el
@@ -4,8 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 06 Jan 2018
-;; Version: 0.8.1
-;; Keywords: jupyter literate-programming
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-c++.el
+++ b/jupyter-c++.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 12 April 2019
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-channel-ioloop-comm.el
+++ b/jupyter-channel-ioloop-comm.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 27 Jun 2019
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-channel-ioloop.el
+++ b/jupyter-channel-ioloop.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 27 Jun 2019
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-channel.el
+++ b/jupyter-channel.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 27 Jun 2019
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-client.el
+++ b/jupyter-client.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 06 Jan 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-comm-layer.el
+++ b/jupyter-comm-layer.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 06 Apr 2019
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-env.el
+++ b/jupyter-env.el
@@ -4,8 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 27 Jun 2019
-;; Version: 0.8.1
-;; Keywords: jupyter
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-ioloop-comm.el
+++ b/jupyter-ioloop-comm.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 27 Jun 2019
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-ioloop.el
+++ b/jupyter-ioloop.el
@@ -4,8 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 03 Nov 2018
-;; Version: 0.8.1
-;; Package-Requires: ((emacs "26"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-javascript.el
+++ b/jupyter-javascript.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 23 Oct 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-julia.el
+++ b/jupyter-julia.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 23 Oct 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-kernel-manager.el
+++ b/jupyter-kernel-manager.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 08 Jan 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-kernel-process-manager.el
+++ b/jupyter-kernel-process-manager.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 08 Aug 2019
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-kernelspec.el
+++ b/jupyter-kernelspec.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 17 Jan 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-messages.el
+++ b/jupyter-messages.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 08 Jan 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-mime.el
+++ b/jupyter-mime.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 09 Nov 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 02 Jun 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-org-extensions.el
+++ b/jupyter-org-extensions.el
@@ -4,7 +4,6 @@
 
 ;; Author: Carlos Garcia C. <carlos@binarycharly.com>
 ;; Created: 01 March 2019
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-python.el
+++ b/jupyter-python.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 23 Oct 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-repl.el
+++ b/jupyter-repl.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 08 Jan 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-rest-api.el
+++ b/jupyter-rest-api.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 03 Apr 2019
-;; Version: 0.7.3
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-server-ioloop.el
+++ b/jupyter-server-ioloop.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 03 Apr 2019
-;; Version: 0.7.3
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-server.el
+++ b/jupyter-server.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 02 Apr 2019
-;; Version: 0.8.0
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-tramp.el
+++ b/jupyter-tramp.el
@@ -4,9 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 25 May 2019
-;; Version: 0.0.1
-;; Keywords: jupyter notebook
-;; X-URL: https://github.com/dzop/emacs-jupyter
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-widget-client.el
+++ b/jupyter-widget-client.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 21 May 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-zmq-channel-comm.el
+++ b/jupyter-zmq-channel-comm.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 27 Jun 2019
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-zmq-channel-ioloop.el
+++ b/jupyter-zmq-channel-ioloop.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 08 Nov 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/jupyter-zmq-channel.el
+++ b/jupyter-zmq-channel.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 27 Jun 2019
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as

--- a/ob-jupyter.el
+++ b/ob-jupyter.el
@@ -4,7 +4,6 @@
 
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 21 Jan 2018
-;; Version: 0.8.1
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License as


### PR DESCRIPTION
Hi!

MELPA references only one main Elisp file, not the headers of the other files.
Writing a version in every subfile violates the DRY principle and, in fact, is not maintainable.
To remedy this situation, simply delete the version description in the subfile and describe the version only in the main Elisp file.

In addition, in jupyter-R.el, Author cannot be parsed by lisp-mnt.el.
My changes allow lisp-mnt to parse headers correctly.

``` emacs-lisp
(with-current-buffer "jupyter-R.el"
  (lm-authors))
;;=> (("Jack Kamm <jackkamm@gmail.com>, Nathaniel Nicandro" . "nathanielnicandro@gmail.com"))

(with-current-buffer "jupyter-R.el"
  (lm-authors))
;;=> (("Jack Kamm" . "jackkamm@gmail.com")
;;    ("Nathaniel Nicandro" . "nathanielnicandro@gmail.com"))
```