### PR TITLE
Fix #219 REPL freezing in Emacs-27

### DIFF
--- a/jupyter-repl.el
+++ b/jupyter-repl.el
@@ -1863,7 +1863,7 @@ VERBOSE has the same meaning as in
   (let (fld frf sff spf comment)
     (jupyter-with-repl-lang-buffer
       (setq fld font-lock-defaults
-            frf (or font-lock-fontify-region-function #'ignore)
+            frf (or #'font-lock-fontify-region #'ignore)
             sff (or font-lock-syntactic-face-function #'ignore)
             spf (or syntax-propertize-function #'ignore)
             comment comment-start))


### PR DESCRIPTION
Fixed the issue of Emacs 27 freezing when sending code to a REPL buffer
with font-lock mode activated. The issue started to happen due to a
refactor of part of the code in `font-lock-default-fontify-region` to `font-lock-fontify-region`.

See https://github.com/dzop/emacs-jupyter/issues/219