### PR TITLE
Add jupyter-describe function for interactive inspect

### DIFF
--- a/README.org
+++ b/README.org
@@ -279,17 +279,18 @@ associate with the =current-buffer= and enable the minor mode
 =jupyter-repl-interaction-mode=. This minor mode populates the following
 keybindings for interacting with the REPL:
 
-| Key binding | Command                       |
-|-------------+-------------------------------|
-| =C-M-x=       | =jupyter-eval-defun=            |
-| =M-i=         | =jupyter-inspect-at-point=      |
-| =C-c C-b=     | =jupyter-eval-buffer=           |
-| =C-c C-c=     | =jupyter-eval-line-or-region=   |
-| =C-c C-i=     | =jupyter-repl-interrupt-kernel= |
-| =C-c C-r=     | =jupyter-repl-restart-kernel=   |
-| =C-c C-s=     | =jupyter-repl-scratch-buffer=   |
-| =C-c C-o=     | =jupyter-eval-remove-overlays=  |
-| =C-c M-:=     | =jupyter-eval-string=           |
+| Key binding | Command                         |
+|-------------+---------------------------------|
+| =C-M-x=     | =jupyter-eval-defun=            |
+| =M-i=       | =jupyter-inspect-at-point=      |
+| =C-c C-d=   | =jupyter-describe=              |
+| =C-c C-b=   | =jupyter-eval-buffer=           |
+| =C-c C-c=   | =jupyter-eval-line-or-region=   |
+| =C-c C-i=   | =jupyter-repl-interrupt-kernel= |
+| =C-c C-r=   | =jupyter-repl-restart-kernel=   |
+| =C-c C-s=   | =jupyter-repl-scratch-buffer=   |
+| =C-c C-o=   | =jupyter-eval-remove-overlays=  |
+| =C-c M-:=   | =jupyter-eval-string=           |
 
 **** Integration with =emacsclient=
 

--- a/jupyter-repl.el
+++ b/jupyter-repl.el
@@ -44,6 +44,7 @@
 ;;     C-c C-c `jupyter-eval-line-or-region'
 ;;     C-c C-l `jupyter-eval-file'
 ;;     M-i `jupyter-inspect-at-point'
+;;     C-c C-d `jupyter-describe'
 ;;     C-c C-r `jupyter-repl-restart-kernel'
 ;;     C-c C-i `jupyter-repl-interrupt-kernel'
 ;;     C-c C-z `jupyter-repl-pop-to-buffer'
@@ -1947,6 +1948,7 @@ the updated state."
     (define-key map (kbd "C-c C-l") #'jupyter-load-file)
     (define-key map (kbd "C-c M-:") #'jupyter-eval-string-command)
     (define-key map (kbd "M-i") #'jupyter-inspect-at-point)
+    (define-key map (kbd "C-c C-d") #'jupyter-describe)
     (define-key map (kbd "C-c C-r") #'jupyter-repl-restart-kernel)
     (define-key map (kbd "C-c C-i") #'jupyter-repl-interrupt-kernel)
     (define-key map (kbd "C-c C-z") #'jupyter-repl-pop-to-buffer)


### PR DESCRIPTION
jupyter-describe implements an interface (with completion) similar to
emacs builtin describe-function for interacting with jupyter kernels.

Closes #199

This was actually easier than I expected, so kudos for the sane architecture. :)