### PR TITLE
Issue true delete requests to the test notebook server.

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -647,7 +647,9 @@ see the documentation on the --NotebookApp.password argument."
               (buffer (generate-new-buffer "*jupyter-notebook*"))
               (args (append
                      (list "notebook" "--no-browser" "--debug"
-                           (format "--NotebookApp.port=%s" port))
+                           (format "--NotebookApp.port=%s" port)
+                           "--FileContentsManager.delete_to_trash=False"
+                           "--FileContentsManager.always_delete_dir=True")
                      (cond
                       ((eq authentication t)
                        (list))


### PR DESCRIPTION
Without these settings, tests that delete files and directories can fail on Unix systems that require special permissions to move temp files to the system "trash" location.

Fixes emacs-jupyter/jupyter#620