### PR TITLE
Emacs v31 compatability 

### DIFF
--- a/jupyter-base.el
+++ b/jupyter-base.el
@@ -421,6 +421,44 @@ will be called when OBJ is garbage collected."
   (cl-check-type finalizer function)
   (push (make-finalizer finalizer) (oref obj finalizers)))
 
+(defvar jupyter--clients nil)
+
+(defclass jupyter-kernel-client (jupyter-instance-tracker
+                                 jupyter-finalized-object)
+  ((tracking-symbol :initform 'jupyter--clients)
+   (execution-state
+    :type string
+    :initform "idle"
+    :documentation "The current state of the kernel.  Can be
+either \"idle\", \"busy\", or \"starting\".")
+   (execution-count
+    :type integer
+    :initform 1
+    :documentation "The *next* execution count of the kernel.
+I.e., the execution count that will be assigned to the
+next :execute-request sent to the kernel.")
+   (kernel-info
+    :type json-plist
+    :initform nil
+    :documentation "The saved kernel info created when first
+initializing this client.")
+   (comms
+    :type hash-table
+    :initform (make-hash-table :test 'equal)
+    :documentation "A hash table with comm ID's as keys.
+Contains all of the open comms.  Each value is a cons cell (REQ .
+DATA) which contains the generating `jupyter-request' that caused
+the comm to open and the initial DATA passed to the comm for
+initialization.")
+   (io
+    :type list
+    :initarg :io
+    :documentation "The I/O context kernel messages are communicated on.")
+   (-buffer
+    :type buffer
+    :documentation "An internal buffer used to store client local
+variables.")))
+
 ;;; Session object definition
 
 (cl-defstruct (jupyter-session

--- a/jupyter-channel-ioloop.el
+++ b/jupyter-channel-ioloop.el
@@ -74,7 +74,7 @@
 
 (jupyter-ioloop-add-arg-type jupyter-channel
   (lambda (arg)
-    `(or (object-assoc ,arg :type jupyter-channel-ioloop-channels)
+    `(or (object-assoc ,arg 'type jupyter-channel-ioloop-channels)
          (error "Channel not alive (%s)" ,arg))))
 
 (defclass jupyter-channel-ioloop (jupyter-ioloop)
@@ -158,7 +158,7 @@ A list with the form
 
 is returned to the parent process."
   (jupyter-ioloop-add-event ioloop stop-channel (type)
-    (let ((channel (object-assoc type :type jupyter-channel-ioloop-channels)))
+    (let ((channel (object-assoc type 'type jupyter-channel-ioloop-channels)))
       (when (and channel (jupyter-alive-p channel))
         (jupyter-stop channel))
       (list 'stop-channel type))))

--- a/jupyter-client.el
+++ b/jupyter-client.el
@@ -172,45 +172,7 @@ In addition, if the first element of the list is the symbol
 Do not set this variable directly, let bind it around specific
 requests like the above example.")
 
-(defvar jupyter--clients nil)
-
 ;; Define channel classes for method dispatching based on the channel type
-
-(defclass jupyter-kernel-client (jupyter-instance-tracker
-                                 jupyter-finalized-object)
-  ((tracking-symbol :initform 'jupyter--clients)
-   (execution-state
-    :type string
-    :initform "idle"
-    :documentation "The current state of the kernel.  Can be
-either \"idle\", \"busy\", or \"starting\".")
-   (execution-count
-    :type integer
-    :initform 1
-    :documentation "The *next* execution count of the kernel.
-I.e., the execution count that will be assigned to the
-next :execute-request sent to the kernel.")
-   (kernel-info
-    :type json-plist
-    :initform nil
-    :documentation "The saved kernel info created when first
-initializing this client.")
-   (comms
-    :type hash-table
-    :initform (make-hash-table :test 'equal)
-    :documentation "A hash table with comm ID's as keys.
-Contains all of the open comms.  Each value is a cons cell (REQ .
-DATA) which contains the generating `jupyter-request' that caused
-the comm to open and the initial DATA passed to the comm for
-initialization.")
-   (io
-    :type list
-    :initarg :io
-    :documentation "The I/O context kernel messages are communicated on.")
-   (-buffer
-    :type buffer
-    :documentation "An internal buffer used to store client local
-variables.")))
 
 ;;; `jupyter-current-client' language method specializer
 

--- a/jupyter-ioloop.el
+++ b/jupyter-ioloop.el
@@ -194,7 +194,7 @@ For example suppose we define an argument type, jupyter-channel:
 
     (jupyter-ioloop-add-arg-type jupyter-channel
       (lambda (arg)
-        `(or (object-assoc ,arg :type jupyter-channel-ioloop-channels)
+        `(or (object-assoc ,arg 'type jupyter-channel-ioloop-channels)
              (error \"Channel not alive (%s)\" ,arg))))
 
 and define an event like

--- a/jupyter-repl.el
+++ b/jupyter-repl.el
@@ -1976,7 +1976,7 @@ from the kernel."
 (defun jupyter-repl-pop-to-buffer ()
   "Switch to the REPL buffer of the `jupyter-current-client'."
   (interactive)
-  (if-let ((client jupyter-current-client))
+  (if-let* ((client jupyter-current-client))
       (progn
         (jupyter-resurrect-repl client)
         (jupyter-with-repl-buffer client

--- a/jupyter-server-kernel.el
+++ b/jupyter-server-kernel.el
@@ -282,7 +282,7 @@ this case FN will be evaluated on KERNEL."
                  ;; TODO: on-error publishes to status-pub
                  :on-message
                  (lambda (_ws frame)
-                   (when-let ((response (jupyter-server-kernel-parse-frame frame)))
+                   (when-let* ((response (jupyter-server-kernel-parse-frame frame)))
                      (pcase (websocket-frame-opcode frame)
                        ((or 'text 'binary 'continuation)
                         (let ((msg (jupyter-read-plist-from-string response)))

--- a/jupyter-zmq-channel-ioloop.el
+++ b/jupyter-zmq-channel-ioloop.el
@@ -49,7 +49,7 @@
     (push 'jupyter-zmq-channel-ioloop--recv-messages jupyter-ioloop-post-hook)
     (cl-loop
      for channel in '(:shell :stdin :iopub :control)
-     unless (object-assoc channel :type jupyter-channel-ioloop-channels)
+     unless (object-assoc channel 'type jupyter-channel-ioloop-channels)
      do (push (jupyter-zmq-channel
                :session jupyter-channel-ioloop-session
                :type channel)

--- a/ob-jupyter.el
+++ b/ob-jupyter.el
@@ -367,7 +367,7 @@ session."
     (org-babel-jupyter-aliases-from-kernelspecs
      nil (jupyter-kernelspecs server))
     (let ((sname (file-local-name rsession)))
-      (if-let ((id (jupyter-server-kernel-id-from-name server sname)))
+      (if-let* ((id (jupyter-server-kernel-id-from-name server sname)))
           ;; Connecting to an existing kernel
           (cl-destructuring-bind (&key name id &allow-other-keys)
               (or (ignore-errors (jupyter-api-get-kernel server id))


### PR DESCRIPTION
These patches makes emacs-jupyter compatible with Emacs-31 on my machine.

The biggest issue seems to be that the EIEIO compatibility layer was disabled in Emacs  31, which seems to cause issues with communicating with zmq. 

I replace `{when,if}-let` with their starred counterparts to silence Emacs warnigns 

And the patch in #619 fixed two optimization failure for cl-typep warnings. 

I tested the patches in Emacs 30 and they work there. I don't have access to older Emacs version. 