### PR TITLE
Send `read`-able representations of messages with complex objects.

### DIFF
--- a/jupyter-ioloop.el
+++ b/jupyter-ioloop.el
@@ -295,7 +295,10 @@ By default this adds the events quit, callback, and timer."
                       (setq jupyter-ioloop-timeout 0)
                       (add-hook 'jupyter-ioloop-pre-hook (byte-compile cb) 'append)))
                    ('(quit) (signal 'quit nil))
-                   (_ (error "Unhandled command %s" cmd)))))
+                   (_ (error "Unhandled command %s" cmd))))
+            (print-circle t)
+            (print-escape-nonascii t)
+            print-level print-length)
        ;; Can only send lists at the moment
        (when (and res (listp res)) (zmq-prin1 res)))))
 
@@ -475,8 +478,11 @@ returning."
         (setq jupyter-ioloop--send-buffer
               (get-buffer-create " *jupyter-ioloop-send*")))
     (erase-buffer)
-    (let (print-level print-length)
-      (prin1 plist (current-buffer)))
+    (prin1 plist (current-buffer)
+           '((circle . t)
+             (escape-nonascii . t)
+             (level . nil)
+             (length . nil)))
     (buffer-string)))
 
 (cl-defmethod jupyter-send ((ioloop jupyter-ioloop) &rest args)

--- a/jupyter-ioloop.el
+++ b/jupyter-ioloop.el
@@ -85,6 +85,15 @@ events have the same value as the return value of
   "Return non-nil if this Emacs instance is an IOLoop subprocess."
   (and noninteractive jupyter-ioloop-stdin jupyter-ioloop-poller))
 
+(defun jupyter-ioloop-prin1 (sexp &optional flush)
+  "Print SEXP using `prin1', and flush `stdout' if FLUSH is non-nil."
+  (prin1 sexp nil '((circle . t)
+                    (escape-nonascii . t)
+                    (level . nil)
+                    (length . nil)))
+  (when flush
+    (zmq-flush 'stdout)))
+
 (defclass jupyter-ioloop (jupyter-finalized-object)
   ((process :type (or null process) :initform nil)
    (callbacks :type list :initform nil)
@@ -295,12 +304,9 @@ By default this adds the events quit, callback, and timer."
                       (setq jupyter-ioloop-timeout 0)
                       (add-hook 'jupyter-ioloop-pre-hook (byte-compile cb) 'append)))
                    ('(quit) (signal 'quit nil))
-                   (_ (error "Unhandled command %s" cmd))))
-            (print-circle t)
-            (print-escape-nonascii t)
-            print-level print-length)
+                   (_ (error "Unhandled command %s" cmd)))))
        ;; Can only send lists at the moment
-       (when (and res (listp res)) (zmq-prin1 res)))))
+       (when (and res (listp res)) (jupyter-ioloop-prin1 res 'flush)))))
 
 (cl-defgeneric jupyter-ioloop-add-callback ()
   (declare (indent 1)))
@@ -314,7 +320,7 @@ WARNING: A function added as a callback should be quoted to avoid
 sending closures to the IOLOOP.  An example:
 
     (jupyter-ioloop-add-callback ioloop
-      `(lambda () (zmq-prin1 \='foo \"bar\")))"
+      `(lambda () (zmq-prin1 \\='foo \"bar\")))"
   (cl-assert (functionp cb))
   (cl-callf append (oref ioloop callbacks) (list cb))
   (when (process-live-p (oref ioloop process))
@@ -354,7 +360,7 @@ nothing."
                             (quote ,(mapcar #'macroexpand-all
                                        (oref ioloop callbacks))))))
            ;; Notify the parent process we are ready to do something
-           (zmq-prin1 '(start))
+           (jupyter-ioloop-prin1 '(start) 'flush)
            (let ((on-stdin (byte-compile (lambda () ,on-stdin))))
              (while t
                (run-hooks 'jupyter-ioloop-pre-hook)
@@ -372,7 +378,7 @@ nothing."
                (run-hook-with-args 'jupyter-ioloop-post-hook events))))
        (quit
         ,@(oref ioloop teardown)
-        (zmq-prin1 '(quit))))))
+        (jupyter-ioloop-prin1 '(quit) 'flush)))))
 
 (defun jupyter-ioloop--function (ioloop port)
   "Return the function that does the work of IOLOOP.
@@ -478,11 +484,8 @@ returning."
         (setq jupyter-ioloop--send-buffer
               (get-buffer-create " *jupyter-ioloop-send*")))
     (erase-buffer)
-    (prin1 plist (current-buffer)
-           '((circle . t)
-             (escape-nonascii . t)
-             (level . nil)
-             (length . nil)))
+    (let ((standard-output (current-buffer)))
+      (jupyter-ioloop-prin1 plist))
     (buffer-string)))
 
 (cl-defmethod jupyter-send ((ioloop jupyter-ioloop) &rest args)

--- a/jupyter-zmq-channel-ioloop.el
+++ b/jupyter-zmq-channel-ioloop.el
@@ -74,7 +74,13 @@ list as returned by `jupyter-recv'."
           (push (cons type (jupyter-recv channel)) messages))))
     (when messages
       ;; Send messages
-      (mapc (lambda (msg) (prin1 (cons 'message msg))) (nreverse messages))
+      (mapc (lambda (msg)
+              (prin1 (cons 'message msg) nil
+                     '((circle . t)
+                       (escape-nonascii . t)
+                       (level . nil)
+                       (length . nil))))
+            (nreverse messages))
       (zmq-flush 'stdout))))
 
 (provide 'jupyter-zmq-channel-ioloop)

--- a/jupyter-zmq-channel-ioloop.el
+++ b/jupyter-zmq-channel-ioloop.el
@@ -75,11 +75,7 @@ list as returned by `jupyter-recv'."
     (when messages
       ;; Send messages
       (mapc (lambda (msg)
-              (prin1 (cons 'message msg) nil
-                     '((circle . t)
-                       (escape-nonascii . t)
-                       (level . nil)
-                       (length . nil))))
+              (jupyter-ioloop-prin1 (cons 'message msg)))
             (nreverse messages))
       (zmq-flush 'stdout))))
 

--- a/test/jupyter-test.el
+++ b/test/jupyter-test.el
@@ -1030,6 +1030,20 @@
     (jupyter-ioloop-stop ioloop)
     (should jupyter-ioloop-test-handler-called)))
 
+(ert-deftest jupyter-ioloop-handle-complex-objects ()
+  :tags '(zmq ioloop)
+  (let ((ioloop (jupyter-ioloop))
+        (msg "circular"))
+    (add-text-properties 0 1 (list :backref msg) msg)
+    (setq jupyter-ioloop-test-handler-called nil)
+    (jupyter-ioloop-add-event ioloop circle (tag data)
+      "Echo DATA back to the parent process."
+      (list 'circle tag data))
+    (jupyter-test-ioloop-start ioloop)
+    (jupyter-send ioloop 'circle "message" msg)
+    (jupyter-ioloop-stop ioloop)
+    (should jupyter-ioloop-test-handler-called)))
+
 (ert-deftest jupyter-channel-ioloop-send-event ()
   :tags '(zmq ioloop)
   (jupyter-test-channel-ioloop


### PR DESCRIPTION
* jupyter-ioloop.el (jupyter-ioloop--event-dispatcher): bind print vars around zmq-prin1
(jupyter-ioloop--dump-message): pass print vars to prin1
* jupyter-zmq-channel-ioloop.el (jupyter-zmq-channel-ioloop--recv-messages): pass print vars to prin1
* test/jupyter-test.el (jupyter-ioloop-send-circular-messages): new test

Fixes emacs-jupyter/jupyter#626.