### PR TITLE
Enable jupyter-org functions when on #begin_src/#end_src

### DIFF
--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -626,7 +626,7 @@ inside a Jupyter src-block, return nil."
                   ;; Move the end marker when text is inserted
                   (set-marker-insertion-type end t)
                   end))))
-  (if (org-in-src-block-p 'inside)
+  (if (org-in-src-block-p)
       (or (jupyter-org--at-cached-src-block-p)
           (when-let* ((el (org-element-at-point))
                       (info (and (eq (org-element-type el) 'src-block)


### PR DESCRIPTION
This changes `jupyter-org--set-src-block-cache` to return `t` when on line `#begin_src ...`/`#end_src` thus enable various jupyter-org functions. In particular, this allows consecutive `jupyter-org-execute-and-next-block`, whereas previously I always have to execute `next-line` after `jupyter-org-execute-and-next-block` so that point is now inside src block before I can execute `jupyter-org-execute-and-next-block` again.